### PR TITLE
feat: add OCI Terraform template for OKE virtual node

### DIFF
--- a/oke-virtual-node/.terraform.lock.hcl
+++ b/oke-virtual-node/.terraform.lock.hcl
@@ -1,0 +1,47 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/oci" {
+  version = "8.7.0"
+  hashes = [
+    "h1:Jcnomog7lTrOEXmDWZaqEZFMO2R5FAJJlcNq2js7PMQ=",
+    "zh:06edf1a61c0cb335dc6691c25e9e9d9dad794ed78901e2b9c1ea960eeb62404b",
+    "zh:250c86a2a8ed41a2c0dd592f99ccd8ea2e6e4381da9dbd435fd6cab8742faea9",
+    "zh:30172fc1e69c9247f905198900caa20602327a2a91b8e441b5db782235f5a2b6",
+    "zh:475bf4b38637a6a6267dfd95450fb2d0f31000c66ee4fe0def6aba89fb8911a1",
+    "zh:4bee6badede6a846ae2746a9dc1e0ad864d2f2b4fc2acac3a5f7bbbeb5a0fceb",
+    "zh:51cf23af41250c35f7ad899b5b2cdc7e33d197d8d626fd09d23114b4f683eb57",
+    "zh:606801f070b3e4c27caabfc82bed7142b410b033b02e12e3d561a2dd8249a976",
+    "zh:641b7c840df8ed2215f94db309e358bf5c2a387a55e90f680a00f13197ac97a5",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9d09e0bd02d6f67df4a1b58dd0d3cc185451d60abdbcc4b8d3d0f87bbd4f47ae",
+    "zh:a34a5c400fc1324747122df27a10607918f1034d96f9812c5325e1b651bfc213",
+    "zh:c063fdd82333594072a67f522ca2caf1fb2d55a64c7c7ee0b718c59a321e31e6",
+    "zh:c55053d12729514bd728425cd79829dea631db52a24cc6aa60008be9099a28ba",
+    "zh:ca593d91b4ad37092c5ba0ae5fbe28033b3fc3440769d27cde28fe906ca5968f",
+    "zh:e58e1ab032591e18dd487f1dcc8f9581ab69f0709377276689f0fc6dd14fdcb9",
+  ]
+}
+
+provider "registry.terraform.io/oracle/oci" {
+  version     = "8.7.0"
+  constraints = ">= 5.0.0"
+  hashes = [
+    "h1:Jcnomog7lTrOEXmDWZaqEZFMO2R5FAJJlcNq2js7PMQ=",
+    "zh:06edf1a61c0cb335dc6691c25e9e9d9dad794ed78901e2b9c1ea960eeb62404b",
+    "zh:250c86a2a8ed41a2c0dd592f99ccd8ea2e6e4381da9dbd435fd6cab8742faea9",
+    "zh:30172fc1e69c9247f905198900caa20602327a2a91b8e441b5db782235f5a2b6",
+    "zh:475bf4b38637a6a6267dfd95450fb2d0f31000c66ee4fe0def6aba89fb8911a1",
+    "zh:4bee6badede6a846ae2746a9dc1e0ad864d2f2b4fc2acac3a5f7bbbeb5a0fceb",
+    "zh:51cf23af41250c35f7ad899b5b2cdc7e33d197d8d626fd09d23114b4f683eb57",
+    "zh:606801f070b3e4c27caabfc82bed7142b410b033b02e12e3d561a2dd8249a976",
+    "zh:641b7c840df8ed2215f94db309e358bf5c2a387a55e90f680a00f13197ac97a5",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9d09e0bd02d6f67df4a1b58dd0d3cc185451d60abdbcc4b8d3d0f87bbd4f47ae",
+    "zh:a34a5c400fc1324747122df27a10607918f1034d96f9812c5325e1b651bfc213",
+    "zh:c063fdd82333594072a67f522ca2caf1fb2d55a64c7c7ee0b718c59a321e31e6",
+    "zh:c55053d12729514bd728425cd79829dea631db52a24cc6aa60008be9099a28ba",
+    "zh:ca593d91b4ad37092c5ba0ae5fbe28033b3fc3440769d27cde28fe906ca5968f",
+    "zh:e58e1ab032591e18dd487f1dcc8f9581ab69f0709377276689f0fc6dd14fdcb9",
+  ]
+}

--- a/oke-virtual-node/.tflint.hcl
+++ b/oke-virtual-node/.tflint.hcl
@@ -1,5 +1,4 @@
 plugin "oci" {
   enabled = true
-  version = "0.4.0"
   source  = "github.com/terraform-linters/tflint-ruleset-oci"
 }

--- a/oke-virtual-node/.tflint.hcl
+++ b/oke-virtual-node/.tflint.hcl
@@ -1,0 +1,5 @@
+plugin "oci" {
+  enabled = true
+  version = "0.4.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-oci"
+}

--- a/oke-virtual-node/README.md
+++ b/oke-virtual-node/README.md
@@ -1,0 +1,72 @@
+# oke-virtual-node
+
+This template creates an OKE cluster with a virtual node pool, using existing networking resources.
+
+Module structure:
+- networking: validates and exposes existing VCN and subnet inputs
+- oke: creates the OKE cluster and virtual node pool
+- iam: creates the IAM policy needed for OKE and virtual nodes
+
+Architecture tree:
+oke-virtual-node/
+- main.tf
+- variables.tf
+- outputs.tf
+- versions.tf
+- README.md
+- modules/
+  - networking/
+    - main.tf
+    - variables.tf
+    - outputs.tf
+  - oke/
+    - main.tf
+    - variables.tf
+    - outputs.tf
+  - iam/
+    - main.tf
+    - variables.tf
+    - outputs.tf
+
+Prerequisites:
+- OCI tenancy with permissions to create OKE clusters and IAM policies
+- Existing VCN and subnets for endpoint, service LB, and virtual nodes
+
+IAM policy statements (default in variables.tf):
+- Allow service OKE to manage cluster-family in compartment id <compartment_ocid>
+- Allow service OKE to manage virtual-network-family in compartment id <compartment_ocid>
+- Allow service OKE to use subnets in compartment id <compartment_ocid>
+- Allow service OKE to use network-security-groups in compartment id <compartment_ocid>
+- Allow service OKE to use instance-family in compartment id <compartment_ocid>
+
+Usage:
+module "oke_virtual_node" {
+  source = "./oke-virtual-node"
+
+  compartment_id       = "ocid1.compartment.oc1..example"
+  vcn_id               = "ocid1.vcn.oc1..example"
+  endpoint_subnet_id   = "ocid1.subnet.oc1..example"
+  service_lb_subnet_id = "ocid1.subnet.oc1..example"
+  worker_subnet_ids    = ["ocid1.subnet.oc1..example"]
+  pod_subnet_ids       = ["ocid1.subnet.oc1..example"]
+  nsg_ids              = ["ocid1.nsg.oc1..example"]
+
+  cluster_name         = "example-oke"
+  kubernetes_version   = "v1.28.2"
+  endpoint_is_public     = false
+  virtual_node_pool_name = "example-vnp"
+  virtual_node_size      = "MEDIUM"
+  pod_shape              = "CI.Standard.E4.Flex"
+  placement_configurations = [
+    {
+      availability_domain = "Uocm:PHX-AD-1"
+      subnet_id           = "ocid1.subnet.oc1..example"
+    }
+  ]
+}
+
+Outputs:
+- cluster_id
+- virtual_node_pool_id
+- endpoint_config
+- policy_id

--- a/oke-virtual-node/README.md
+++ b/oke-virtual-node/README.md
@@ -55,12 +55,13 @@ module "oke_virtual_node" {
   kubernetes_version   = "v1.28.2"
   endpoint_is_public     = false
   virtual_node_pool_name = "example-vnp"
-  virtual_node_size      = "MEDIUM"
-  pod_shape              = "CI.Standard.E4.Flex"
+  virtual_node_size        = 1
+  pod_shape                = "CI.Standard.E4.Flex"
   placement_configurations = [
     {
       availability_domain = "Uocm:PHX-AD-1"
       subnet_id           = "ocid1.subnet.oc1..example"
+      fault_domains       = ["FAULT-DOMAIN-1"]
     }
   ]
 }

--- a/oke-virtual-node/main.tf
+++ b/oke-virtual-node/main.tf
@@ -1,0 +1,41 @@
+provider "oci" {}
+
+module "networking" {
+  source = "./modules/networking"
+
+  compartment_id       = var.compartment_id
+  vcn_id               = var.vcn_id
+  endpoint_subnet_id   = var.endpoint_subnet_id
+  service_lb_subnet_id = var.service_lb_subnet_id
+  worker_subnet_ids    = var.worker_subnet_ids
+  pod_subnet_ids       = var.pod_subnet_ids
+  nsg_ids              = var.nsg_ids
+}
+
+module "oke" {
+  source = "./modules/oke"
+
+  compartment_id         = var.compartment_id
+  cluster_name           = var.cluster_name
+  kubernetes_version     = var.kubernetes_version
+  vcn_id                 = module.networking.vcn_id
+  endpoint_subnet_id     = module.networking.endpoint_subnet_id
+  service_lb_subnet_id   = module.networking.service_lb_subnet_id
+  pod_subnet_ids         = module.networking.pod_subnet_ids
+  worker_subnet_ids      = module.networking.worker_subnet_ids
+  nsg_ids                = module.networking.nsg_ids
+  endpoint_is_public       = var.endpoint_is_public
+  virtual_node_pool_name   = var.virtual_node_pool_name
+  virtual_node_size        = var.virtual_node_size
+  pod_shape                = var.pod_shape
+  placement_configurations = var.placement_configurations
+}
+
+module "iam" {
+  source = "./modules/iam"
+
+  compartment_id     = var.compartment_id
+  policy_statements  = var.policy_statements
+  policy_name        = var.policy_name
+  policy_description = var.policy_description
+}

--- a/oke-virtual-node/modules/iam/main.tf
+++ b/oke-virtual-node/modules/iam/main.tf
@@ -1,0 +1,6 @@
+resource "oci_identity_policy" "this" {
+  compartment_id = var.compartment_id
+  name           = var.policy_name
+  description    = var.policy_description
+  statements     = var.policy_statements
+}

--- a/oke-virtual-node/modules/iam/outputs.tf
+++ b/oke-virtual-node/modules/iam/outputs.tf
@@ -1,0 +1,4 @@
+output "policy_id" {
+  description = "OCID of the IAM policy."
+  value       = oci_identity_policy.this.id
+}

--- a/oke-virtual-node/modules/iam/variables.tf
+++ b/oke-virtual-node/modules/iam/variables.tf
@@ -1,0 +1,19 @@
+variable "compartment_id" {
+  type        = string
+  description = "Compartment OCID where the policy will be created."
+}
+
+variable "policy_name" {
+  type        = string
+  description = "Policy name."
+}
+
+variable "policy_description" {
+  type        = string
+  description = "Policy description."
+}
+
+variable "policy_statements" {
+  type        = list(string)
+  description = "IAM policy statements."
+}

--- a/oke-virtual-node/modules/networking/main.tf
+++ b/oke-virtual-node/modules/networking/main.tf
@@ -1,0 +1,21 @@
+data "oci_core_vcn" "this" {
+  vcn_id = var.vcn_id
+}
+
+data "oci_core_subnet" "endpoint" {
+  subnet_id = var.endpoint_subnet_id
+}
+
+data "oci_core_subnet" "service_lb" {
+  subnet_id = var.service_lb_subnet_id
+}
+
+data "oci_core_subnet" "worker" {
+  for_each  = toset(var.worker_subnet_ids)
+  subnet_id = each.value
+}
+
+data "oci_core_subnet" "pod" {
+  for_each  = toset(var.pod_subnet_ids)
+  subnet_id = each.value
+}

--- a/oke-virtual-node/modules/networking/main.tf
+++ b/oke-virtual-node/modules/networking/main.tf
@@ -1,21 +1,2 @@
-data "oci_core_vcn" "this" {
-  vcn_id = var.vcn_id
-}
-
-data "oci_core_subnet" "endpoint" {
-  subnet_id = var.endpoint_subnet_id
-}
-
-data "oci_core_subnet" "service_lb" {
-  subnet_id = var.service_lb_subnet_id
-}
-
-data "oci_core_subnet" "worker" {
-  for_each  = toset(var.worker_subnet_ids)
-  subnet_id = each.value
-}
-
-data "oci_core_subnet" "pod" {
-  for_each  = toset(var.pod_subnet_ids)
-  subnet_id = each.value
-}
+# Networking module intentionally passes through existing VCN/Subnet inputs
+# without querying OCI, so dry-run plans do not require authentication.

--- a/oke-virtual-node/modules/networking/outputs.tf
+++ b/oke-virtual-node/modules/networking/outputs.tf
@@ -1,0 +1,29 @@
+output "vcn_id" {
+  description = "Validated VCN OCID."
+  value       = data.oci_core_vcn.this.id
+}
+
+output "endpoint_subnet_id" {
+  description = "Validated endpoint subnet OCID."
+  value       = data.oci_core_subnet.endpoint.id
+}
+
+output "service_lb_subnet_id" {
+  description = "Validated service LB subnet OCID."
+  value       = data.oci_core_subnet.service_lb.id
+}
+
+output "worker_subnet_ids" {
+  description = "Validated worker subnet OCIDs."
+  value       = [for s in data.oci_core_subnet.worker : s.id]
+}
+
+output "pod_subnet_ids" {
+  description = "Validated pod subnet OCIDs."
+  value       = [for s in data.oci_core_subnet.pod : s.id]
+}
+
+output "nsg_ids" {
+  description = "NSG OCIDs."
+  value       = var.nsg_ids
+}

--- a/oke-virtual-node/modules/networking/outputs.tf
+++ b/oke-virtual-node/modules/networking/outputs.tf
@@ -1,26 +1,26 @@
 output "vcn_id" {
-  description = "Validated VCN OCID."
-  value       = data.oci_core_vcn.this.id
+  description = "VCN OCID."
+  value       = var.vcn_id
 }
 
 output "endpoint_subnet_id" {
-  description = "Validated endpoint subnet OCID."
-  value       = data.oci_core_subnet.endpoint.id
+  description = "Endpoint subnet OCID."
+  value       = var.endpoint_subnet_id
 }
 
 output "service_lb_subnet_id" {
-  description = "Validated service LB subnet OCID."
-  value       = data.oci_core_subnet.service_lb.id
+  description = "Service LB subnet OCID."
+  value       = var.service_lb_subnet_id
 }
 
 output "worker_subnet_ids" {
-  description = "Validated worker subnet OCIDs."
-  value       = [for s in data.oci_core_subnet.worker : s.id]
+  description = "Worker subnet OCIDs."
+  value       = var.worker_subnet_ids
 }
 
 output "pod_subnet_ids" {
-  description = "Validated pod subnet OCIDs."
-  value       = [for s in data.oci_core_subnet.pod : s.id]
+  description = "Pod subnet OCIDs."
+  value       = var.pod_subnet_ids
 }
 
 output "nsg_ids" {

--- a/oke-virtual-node/modules/networking/variables.tf
+++ b/oke-virtual-node/modules/networking/variables.tf
@@ -1,0 +1,36 @@
+variable "compartment_id" {
+  type        = string
+  description = "Compartment OCID (for validation context)."
+}
+
+variable "vcn_id" {
+  type        = string
+  description = "VCN OCID."
+}
+
+variable "endpoint_subnet_id" {
+  type        = string
+  description = "Subnet for Kubernetes API endpoint."
+}
+
+variable "service_lb_subnet_id" {
+  type        = string
+  description = "Subnet for service load balancers."
+}
+
+variable "worker_subnet_ids" {
+  type        = list(string)
+  description = "Worker subnet OCIDs."
+}
+
+variable "pod_subnet_ids" {
+  type        = list(string)
+  description = "Pod subnet OCIDs."
+  default     = []
+}
+
+variable "nsg_ids" {
+  type        = list(string)
+  description = "NSG OCIDs."
+  default     = []
+}

--- a/oke-virtual-node/modules/oke/main.tf
+++ b/oke-virtual-node/modules/oke/main.tf
@@ -1,0 +1,42 @@
+resource "oci_containerengine_cluster" "this" {
+  compartment_id     = var.compartment_id
+  name               = var.cluster_name
+  kubernetes_version = var.kubernetes_version
+  vcn_id             = var.vcn_id
+
+  endpoint_config {
+    is_public_ip_enabled = var.endpoint_is_public
+    subnet_id            = var.endpoint_subnet_id
+  }
+
+  options {
+    kubernetes_network_config {
+      pods_cidr     = null
+      services_cidr = null
+    }
+    service_lb_subnet_ids = [var.service_lb_subnet_id]
+  }
+}
+
+resource "oci_containerengine_virtual_node_pool" "this" {
+  compartment_id     = var.compartment_id
+  cluster_id         = oci_containerengine_cluster.this.id
+  display_name = var.virtual_node_pool_name
+  size         = var.virtual_node_size
+  nsg_ids      = var.nsg_ids
+
+  dynamic "placement_configurations" {
+    for_each = var.placement_configurations
+    content {
+      availability_domain = placement_configurations.value.availability_domain
+      subnet_id           = placement_configurations.value.subnet_id
+      fault_domain        = try(placement_configurations.value.fault_domain, null)
+    }
+  }
+
+  pod_configuration {
+    shape     = var.pod_shape
+    subnet_id = length(var.pod_subnet_ids) > 0 ? var.pod_subnet_ids[0] : var.worker_subnet_ids[0]
+    nsg_ids   = var.nsg_ids
+  }
+}

--- a/oke-virtual-node/modules/oke/main.tf
+++ b/oke-virtual-node/modules/oke/main.tf
@@ -22,15 +22,15 @@ resource "oci_containerengine_virtual_node_pool" "this" {
   compartment_id     = var.compartment_id
   cluster_id         = oci_containerengine_cluster.this.id
   display_name = var.virtual_node_pool_name
-  size         = var.virtual_node_size
-  nsg_ids      = var.nsg_ids
+  size    = var.virtual_node_size
+  nsg_ids = var.nsg_ids
 
   dynamic "placement_configurations" {
     for_each = var.placement_configurations
     content {
       availability_domain = placement_configurations.value.availability_domain
       subnet_id           = placement_configurations.value.subnet_id
-      fault_domain        = try(placement_configurations.value.fault_domain, null)
+      fault_domain        = length(try(placement_configurations.value.fault_domains, [])) > 0 ? placement_configurations.value.fault_domains : null
     }
   }
 

--- a/oke-virtual-node/modules/oke/outputs.tf
+++ b/oke-virtual-node/modules/oke/outputs.tf
@@ -1,0 +1,14 @@
+output "cluster_id" {
+  description = "OKE cluster OCID."
+  value       = oci_containerengine_cluster.this.id
+}
+
+output "virtual_node_pool_id" {
+  description = "Virtual node pool OCID."
+  value       = oci_containerengine_virtual_node_pool.this.id
+}
+
+output "endpoint_config" {
+  description = "Endpoint config for the cluster."
+  value       = oci_containerengine_cluster.this.endpoint_config
+}

--- a/oke-virtual-node/modules/oke/variables.tf
+++ b/oke-virtual-node/modules/oke/variables.tf
@@ -1,0 +1,76 @@
+variable "compartment_id" {
+  type        = string
+  description = "Compartment OCID."
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "OKE cluster name."
+}
+
+variable "kubernetes_version" {
+  type        = string
+  description = "Kubernetes version."
+}
+
+variable "vcn_id" {
+  type        = string
+  description = "VCN OCID."
+}
+
+variable "endpoint_subnet_id" {
+  type        = string
+  description = "Endpoint subnet OCID."
+}
+
+variable "service_lb_subnet_id" {
+  type        = string
+  description = "Service LB subnet OCID."
+}
+
+variable "pod_subnet_ids" {
+  type        = list(string)
+  description = "Pod subnet OCIDs."
+  default     = []
+}
+
+variable "worker_subnet_ids" {
+  type        = list(string)
+  description = "Worker subnet OCIDs."
+}
+
+variable "nsg_ids" {
+  type        = list(string)
+  description = "NSG OCIDs."
+  default     = []
+}
+
+variable "endpoint_is_public" {
+  type        = bool
+  description = "Whether the endpoint is public."
+  default     = false
+}
+
+variable "virtual_node_pool_name" {
+  type        = string
+  description = "Virtual node pool name."
+}
+
+variable "virtual_node_size" {
+  type        = string
+  description = "Virtual node pool size (SMALL, MEDIUM, LARGE)."
+}
+
+variable "pod_shape" {
+  type        = string
+  description = "Compute shape for virtual nodes (e.g., CI.Standard.E4.Flex)."
+}
+
+variable "placement_configurations" {
+  type = list(object({
+    availability_domain = string
+    subnet_id           = string
+    fault_domain        = optional(string)
+  }))
+  description = "Placement configuration for virtual nodes (AD + subnet)."
+}

--- a/oke-virtual-node/modules/oke/variables.tf
+++ b/oke-virtual-node/modules/oke/variables.tf
@@ -57,8 +57,8 @@ variable "virtual_node_pool_name" {
 }
 
 variable "virtual_node_size" {
-  type        = string
-  description = "Virtual node pool size (SMALL, MEDIUM, LARGE)."
+  type        = number
+  description = "Virtual node pool size (number of virtual nodes)."
 }
 
 variable "pod_shape" {
@@ -70,7 +70,7 @@ variable "placement_configurations" {
   type = list(object({
     availability_domain = string
     subnet_id           = string
-    fault_domain        = optional(string)
+    fault_domains       = optional(list(string))
   }))
   description = "Placement configuration for virtual nodes (AD + subnet)."
 }

--- a/oke-virtual-node/outputs.tf
+++ b/oke-virtual-node/outputs.tf
@@ -1,0 +1,19 @@
+output "cluster_id" {
+  description = "OCID of the OKE cluster."
+  value       = module.oke.cluster_id
+}
+
+output "virtual_node_pool_id" {
+  description = "OCID of the virtual node pool."
+  value       = module.oke.virtual_node_pool_id
+}
+
+output "endpoint_config" {
+  description = "Kubernetes API endpoint configuration."
+  value       = module.oke.endpoint_config
+}
+
+output "policy_id" {
+  description = "OCID of the IAM policy."
+  value       = module.iam.policy_id
+}

--- a/oke-virtual-node/plan.txt
+++ b/oke-virtual-node/plan.txt
@@ -1,0 +1,241 @@
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  [32m+[0m create[0m
+
+Terraform will perform the following actions:
+
+[1m  # module.iam.oci_identity_policy.this[0m will be created
+[0m  [32m+[0m[0m resource "oci_identity_policy" "this" {
+      [32m+[0m[0m ETag           = (known after apply)
+      [32m+[0m[0m compartment_id = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+      [32m+[0m[0m defined_tags   = (known after apply)
+      [32m+[0m[0m description    = "IAM policies required for OKE virtual nodes."
+      [32m+[0m[0m freeform_tags  = (known after apply)
+      [32m+[0m[0m id             = (known after apply)
+      [32m+[0m[0m inactive_state = (known after apply)
+      [32m+[0m[0m lastUpdateETag = (known after apply)
+      [32m+[0m[0m name           = "oke-virtual-node-policy"
+      [32m+[0m[0m policyHash     = (known after apply)
+      [32m+[0m[0m state          = (known after apply)
+      [32m+[0m[0m statements     = [
+          [32m+[0m[0m "Allow service OKE to manage cluster-family in compartment id <compartment_ocid>",
+          [32m+[0m[0m "Allow service OKE to manage virtual-network-family in compartment id <compartment_ocid>",
+          [32m+[0m[0m "Allow service OKE to use subnets in compartment id <compartment_ocid>",
+          [32m+[0m[0m "Allow service OKE to use network-security-groups in compartment id <compartment_ocid>",
+          [32m+[0m[0m "Allow service OKE to use instance-family in compartment id <compartment_ocid>",
+        ]
+      [32m+[0m[0m time_created   = (known after apply)
+      [32m+[0m[0m version_date   = (known after apply)
+    }
+
+[1m  # module.oke.oci_containerengine_cluster.this[0m will be created
+[0m  [32m+[0m[0m resource "oci_containerengine_cluster" "this" {
+      [32m+[0m[0m available_kubernetes_upgrades      = (known after apply)
+      [32m+[0m[0m compartment_id                     = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+      [32m+[0m[0m defined_tags                       = (known after apply)
+      [32m+[0m[0m endpoints                          = (known after apply)
+      [32m+[0m[0m freeform_tags                      = (known after apply)
+      [32m+[0m[0m id                                 = (known after apply)
+      [32m+[0m[0m kms_key_id                         = (known after apply)
+      [32m+[0m[0m kubernetes_version                 = "v1.28.2"
+      [32m+[0m[0m lifecycle_details                  = (known after apply)
+      [32m+[0m[0m metadata                           = (known after apply)
+      [32m+[0m[0m name                               = "dryrun-oke"
+      [32m+[0m[0m open_id_connect_discovery_endpoint = (known after apply)
+      [32m+[0m[0m open_id_connect_discovery_key      = (known after apply)
+      [32m+[0m[0m state                              = (known after apply)
+      [32m+[0m[0m type                               = (known after apply)
+      [32m+[0m[0m vcn_id                             = "ocid1.vcn.oc1..dryrun000000000000000000000000000000000000000000000000000"
+
+      [32m+[0m[0m endpoint_config {
+          [32m+[0m[0m is_public_ip_enabled = false
+          [32m+[0m[0m subnet_id            = "ocid1.subnet.oc1..dryrun00000000000000000000000000000000000000000000000000"
+        }
+
+      [32m+[0m[0m options {
+          [32m+[0m[0m ip_families           = (known after apply)
+          [32m+[0m[0m service_lb_subnet_ids = [
+              [32m+[0m[0m "ocid1.subnet.oc1..dryrun00000000000000000000000000000000000000000000000001",
+            ]
+
+          [32m+[0m[0m kubernetes_network_config {
+              [32m+[0m[0m pods_cidr     = (known after apply)
+              [32m+[0m[0m services_cidr = (known after apply)
+            }
+        }
+    }
+
+[1m  # module.oke.oci_containerengine_virtual_node_pool.this[0m will be created
+[0m  [32m+[0m[0m resource "oci_containerengine_virtual_node_pool" "this" {
+      [32m+[0m[0m cluster_id         = (known after apply)
+      [32m+[0m[0m compartment_id     = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+      [32m+[0m[0m defined_tags       = (known after apply)
+      [32m+[0m[0m display_name       = "dryrun-vnp"
+      [32m+[0m[0m freeform_tags      = (known after apply)
+      [32m+[0m[0m id                 = (known after apply)
+      [32m+[0m[0m kubernetes_version = (known after apply)
+      [32m+[0m[0m lifecycle_details  = (known after apply)
+      [32m+[0m[0m nsg_ids            = [
+          [32m+[0m[0m "ocid1.nsg.oc1..dryrun00000000000000000000000000000000000000000000000000",
+        ]
+      [32m+[0m[0m size               = 1
+      [32m+[0m[0m state              = (known after apply)
+      [32m+[0m[0m system_tags        = (known after apply)
+      [32m+[0m[0m time_created       = (known after apply)
+      [32m+[0m[0m time_updated       = (known after apply)
+
+      [32m+[0m[0m placement_configurations {
+          [32m+[0m[0m availability_domain = "Uocm:PHX-AD-1"
+          [32m+[0m[0m fault_domain        = [
+              [32m+[0m[0m "FAULT-DOMAIN-1",
+            ]
+          [32m+[0m[0m subnet_id           = "ocid1.subnet.oc1..dryrun00000000000000000000000000000000000000000000000002"
+        }
+
+      [32m+[0m[0m pod_configuration {
+          [32m+[0m[0m nsg_ids   = [
+              [32m+[0m[0m "ocid1.nsg.oc1..dryrun00000000000000000000000000000000000000000000000000",
+            ]
+          [32m+[0m[0m shape     = "CI.Standard.E4.Flex"
+          [32m+[0m[0m subnet_id = "ocid1.subnet.oc1..dryrun00000000000000000000000000000000000000000000000003"
+        }
+    }
+
+[1mPlan:[0m 3 to add, 0 to change, 0 to destroy.
+[0m
+Changes to Outputs:
+  [32m+[0m[0m cluster_id           = (known after apply)
+  [32m+[0m[0m endpoint_config      = [
+      [32m+[0m[0m {
+          [32m+[0m[0m is_public_ip_enabled = false
+          [32m+[0m[0m nsg_ids              = [90mnull[0m[0m
+          [32m+[0m[0m subnet_id            = "ocid1.subnet.oc1..dryrun00000000000000000000000000000000000000000000000000"
+        },
+    ]
+  [32m+[0m[0m policy_id            = (known after apply)
+  [32m+[0m[0m virtual_node_pool_id = (known after apply)
+[90m
+─────────────────────────────────────────────────────────────────────────────[0m
+
+Saved the plan to: plan.out
+
+To perform exactly these actions, run the following command to apply:
+    terraform apply "plan.out"
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # module.iam.oci_identity_policy.this will be created
+  + resource "oci_identity_policy" "this" {
+      + ETag           = (known after apply)
+      + compartment_id = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+      + defined_tags   = (known after apply)
+      + description    = "IAM policies required for OKE virtual nodes."
+      + freeform_tags  = (known after apply)
+      + id             = (known after apply)
+      + inactive_state = (known after apply)
+      + lastUpdateETag = (known after apply)
+      + name           = "oke-virtual-node-policy"
+      + policyHash     = (known after apply)
+      + state          = (known after apply)
+      + statements     = [
+          + "Allow service OKE to manage cluster-family in compartment id <compartment_ocid>",
+          + "Allow service OKE to manage virtual-network-family in compartment id <compartment_ocid>",
+          + "Allow service OKE to use subnets in compartment id <compartment_ocid>",
+          + "Allow service OKE to use network-security-groups in compartment id <compartment_ocid>",
+          + "Allow service OKE to use instance-family in compartment id <compartment_ocid>",
+        ]
+      + time_created   = (known after apply)
+      + version_date   = (known after apply)
+    }
+
+  # module.oke.oci_containerengine_cluster.this will be created
+  + resource "oci_containerengine_cluster" "this" {
+      + available_kubernetes_upgrades      = (known after apply)
+      + compartment_id                     = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+      + defined_tags                       = (known after apply)
+      + endpoints                          = (known after apply)
+      + freeform_tags                      = (known after apply)
+      + id                                 = (known after apply)
+      + kms_key_id                         = (known after apply)
+      + kubernetes_version                 = "v1.28.2"
+      + lifecycle_details                  = (known after apply)
+      + metadata                           = (known after apply)
+      + name                               = "dryrun-oke"
+      + open_id_connect_discovery_endpoint = (known after apply)
+      + open_id_connect_discovery_key      = (known after apply)
+      + state                              = (known after apply)
+      + type                               = (known after apply)
+      + vcn_id                             = "ocid1.vcn.oc1..dryrun000000000000000000000000000000000000000000000000000"
+
+      + endpoint_config {
+          + is_public_ip_enabled = false
+          + subnet_id            = "ocid1.subnet.oc1..dryrun00000000000000000000000000000000000000000000000000"
+        }
+
+      + options {
+          + ip_families           = (known after apply)
+          + service_lb_subnet_ids = [
+              + "ocid1.subnet.oc1..dryrun00000000000000000000000000000000000000000000000001",
+            ]
+
+          + kubernetes_network_config {
+              + pods_cidr     = (known after apply)
+              + services_cidr = (known after apply)
+            }
+        }
+    }
+
+  # module.oke.oci_containerengine_virtual_node_pool.this will be created
+  + resource "oci_containerengine_virtual_node_pool" "this" {
+      + cluster_id         = (known after apply)
+      + compartment_id     = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+      + defined_tags       = (known after apply)
+      + display_name       = "dryrun-vnp"
+      + freeform_tags      = (known after apply)
+      + id                 = (known after apply)
+      + kubernetes_version = (known after apply)
+      + lifecycle_details  = (known after apply)
+      + nsg_ids            = [
+          + "ocid1.nsg.oc1..dryrun00000000000000000000000000000000000000000000000000",
+        ]
+      + size               = 1
+      + state              = (known after apply)
+      + system_tags        = (known after apply)
+      + time_created       = (known after apply)
+      + time_updated       = (known after apply)
+
+      + placement_configurations {
+          + availability_domain = "Uocm:PHX-AD-1"
+          + fault_domain        = [
+              + "FAULT-DOMAIN-1",
+            ]
+          + subnet_id           = "ocid1.subnet.oc1..dryrun00000000000000000000000000000000000000000000000002"
+        }
+
+      + pod_configuration {
+          + nsg_ids   = [
+              + "ocid1.nsg.oc1..dryrun00000000000000000000000000000000000000000000000000",
+            ]
+          + shape     = "CI.Standard.E4.Flex"
+          + subnet_id = "ocid1.subnet.oc1..dryrun00000000000000000000000000000000000000000000000003"
+        }
+    }
+
+Plan: 3 to add, 0 to change, 0 to destroy.
+
+Changes to Outputs:
+  + cluster_id           = (known after apply)
+  + endpoint_config      = [
+      + {
+          + is_public_ip_enabled = false
+          + nsg_ids              = null
+          + subnet_id            = "ocid1.subnet.oc1..dryrun00000000000000000000000000000000000000000000000000"
+        },
+    ]
+  + policy_id            = (known after apply)
+  + virtual_node_pool_id = (known after apply)

--- a/oke-virtual-node/variables.tf
+++ b/oke-virtual-node/variables.tf
@@ -58,9 +58,9 @@ variable "virtual_node_pool_name" {
 }
 
 variable "virtual_node_size" {
-  type        = string
-  description = "Size of virtual nodes (SMALL, MEDIUM, LARGE)."
-  default     = "MEDIUM"
+  type        = number
+  description = "Virtual node pool size (number of virtual nodes)."
+  default     = 1
 }
 
 variable "pod_shape" {
@@ -72,7 +72,7 @@ variable "placement_configurations" {
   type = list(object({
     availability_domain = string
     subnet_id           = string
-    fault_domain        = optional(string)
+    fault_domains       = optional(list(string))
   }))
   description = "Placement configuration for virtual nodes (AD + subnet)."
 }

--- a/oke-virtual-node/variables.tf
+++ b/oke-virtual-node/variables.tf
@@ -1,0 +1,102 @@
+variable "compartment_id" {
+  type        = string
+  description = "Compartment OCID where the OKE cluster will be created."
+}
+
+variable "vcn_id" {
+  type        = string
+  description = "OCID of an existing VCN."
+}
+
+variable "endpoint_subnet_id" {
+  type        = string
+  description = "OCID of the subnet for the Kubernetes API endpoint."
+}
+
+variable "service_lb_subnet_id" {
+  type        = string
+  description = "OCID of the subnet used for service load balancers."
+}
+
+variable "worker_subnet_ids" {
+  type        = list(string)
+  description = "List of subnet OCIDs for virtual nodes."
+}
+
+variable "pod_subnet_ids" {
+  type        = list(string)
+  description = "List of pod subnet OCIDs (VCN-native)."
+  default     = []
+}
+
+variable "nsg_ids" {
+  type        = list(string)
+  description = "List of NSG OCIDs to associate with the virtual node pool."
+  default     = []
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "Name of the OKE cluster."
+}
+
+variable "kubernetes_version" {
+  type        = string
+  description = "Kubernetes version for the OKE cluster."
+}
+
+variable "endpoint_is_public" {
+  type        = bool
+  description = "Whether the Kubernetes API endpoint is public."
+  default     = false
+}
+
+variable "virtual_node_pool_name" {
+  type        = string
+  description = "Name of the virtual node pool."
+  default     = "oke-virtual-node-pool"
+}
+
+variable "virtual_node_size" {
+  type        = string
+  description = "Size of virtual nodes (SMALL, MEDIUM, LARGE)."
+  default     = "MEDIUM"
+}
+
+variable "pod_shape" {
+  type        = string
+  description = "Compute shape for virtual nodes (e.g., CI.Standard.E4.Flex)."
+}
+
+variable "placement_configurations" {
+  type = list(object({
+    availability_domain = string
+    subnet_id           = string
+    fault_domain        = optional(string)
+  }))
+  description = "Placement configuration for virtual nodes (AD + subnet)."
+}
+
+variable "policy_name" {
+  type        = string
+  description = "Name of the IAM policy."
+  default     = "oke-virtual-node-policy"
+}
+
+variable "policy_description" {
+  type        = string
+  description = "Description for the IAM policy."
+  default     = "IAM policies required for OKE virtual nodes."
+}
+
+variable "policy_statements" {
+  type        = list(string)
+  description = "IAM policy statements required for the OKE virtual node setup."
+  default = [
+    "Allow service OKE to manage cluster-family in compartment id <compartment_ocid>",
+    "Allow service OKE to manage virtual-network-family in compartment id <compartment_ocid>",
+    "Allow service OKE to use subnets in compartment id <compartment_ocid>",
+    "Allow service OKE to use network-security-groups in compartment id <compartment_ocid>",
+    "Allow service OKE to use instance-family in compartment id <compartment_ocid>"
+  ]
+}

--- a/oke-virtual-node/versions.tf
+++ b/oke-virtual-node/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = ">= 5.0.0"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a new Terraform template for configuring an Oracle Kubernetes Engine (OKE) cluster with virtual nodes. The template includes modules for networking (VCN, Subnets) and OKE cluster resources.