### PR TITLE
feat: add OCI Terraform template — gateway-instance-autoscale

### DIFF
--- a/gateway-instance-autoscale/.terraform.lock.hcl
+++ b/gateway-instance-autoscale/.terraform.lock.hcl
@@ -1,0 +1,47 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/oci" {
+  version = "8.7.0"
+  hashes = [
+    "h1:Jcnomog7lTrOEXmDWZaqEZFMO2R5FAJJlcNq2js7PMQ=",
+    "zh:06edf1a61c0cb335dc6691c25e9e9d9dad794ed78901e2b9c1ea960eeb62404b",
+    "zh:250c86a2a8ed41a2c0dd592f99ccd8ea2e6e4381da9dbd435fd6cab8742faea9",
+    "zh:30172fc1e69c9247f905198900caa20602327a2a91b8e441b5db782235f5a2b6",
+    "zh:475bf4b38637a6a6267dfd95450fb2d0f31000c66ee4fe0def6aba89fb8911a1",
+    "zh:4bee6badede6a846ae2746a9dc1e0ad864d2f2b4fc2acac3a5f7bbbeb5a0fceb",
+    "zh:51cf23af41250c35f7ad899b5b2cdc7e33d197d8d626fd09d23114b4f683eb57",
+    "zh:606801f070b3e4c27caabfc82bed7142b410b033b02e12e3d561a2dd8249a976",
+    "zh:641b7c840df8ed2215f94db309e358bf5c2a387a55e90f680a00f13197ac97a5",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9d09e0bd02d6f67df4a1b58dd0d3cc185451d60abdbcc4b8d3d0f87bbd4f47ae",
+    "zh:a34a5c400fc1324747122df27a10607918f1034d96f9812c5325e1b651bfc213",
+    "zh:c063fdd82333594072a67f522ca2caf1fb2d55a64c7c7ee0b718c59a321e31e6",
+    "zh:c55053d12729514bd728425cd79829dea631db52a24cc6aa60008be9099a28ba",
+    "zh:ca593d91b4ad37092c5ba0ae5fbe28033b3fc3440769d27cde28fe906ca5968f",
+    "zh:e58e1ab032591e18dd487f1dcc8f9581ab69f0709377276689f0fc6dd14fdcb9",
+  ]
+}
+
+provider "registry.terraform.io/oracle/oci" {
+  version     = "8.7.0"
+  constraints = ">= 5.0.0"
+  hashes = [
+    "h1:Jcnomog7lTrOEXmDWZaqEZFMO2R5FAJJlcNq2js7PMQ=",
+    "zh:06edf1a61c0cb335dc6691c25e9e9d9dad794ed78901e2b9c1ea960eeb62404b",
+    "zh:250c86a2a8ed41a2c0dd592f99ccd8ea2e6e4381da9dbd435fd6cab8742faea9",
+    "zh:30172fc1e69c9247f905198900caa20602327a2a91b8e441b5db782235f5a2b6",
+    "zh:475bf4b38637a6a6267dfd95450fb2d0f31000c66ee4fe0def6aba89fb8911a1",
+    "zh:4bee6badede6a846ae2746a9dc1e0ad864d2f2b4fc2acac3a5f7bbbeb5a0fceb",
+    "zh:51cf23af41250c35f7ad899b5b2cdc7e33d197d8d626fd09d23114b4f683eb57",
+    "zh:606801f070b3e4c27caabfc82bed7142b410b033b02e12e3d561a2dd8249a976",
+    "zh:641b7c840df8ed2215f94db309e358bf5c2a387a55e90f680a00f13197ac97a5",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9d09e0bd02d6f67df4a1b58dd0d3cc185451d60abdbcc4b8d3d0f87bbd4f47ae",
+    "zh:a34a5c400fc1324747122df27a10607918f1034d96f9812c5325e1b651bfc213",
+    "zh:c063fdd82333594072a67f522ca2caf1fb2d55a64c7c7ee0b718c59a321e31e6",
+    "zh:c55053d12729514bd728425cd79829dea631db52a24cc6aa60008be9099a28ba",
+    "zh:ca593d91b4ad37092c5ba0ae5fbe28033b3fc3440769d27cde28fe906ca5968f",
+    "zh:e58e1ab032591e18dd487f1dcc8f9581ab69f0709377276689f0fc6dd14fdcb9",
+  ]
+}

--- a/gateway-instance-autoscale/README.md
+++ b/gateway-instance-autoscale/README.md
@@ -1,0 +1,82 @@
+# gateway-instance-autoscale
+
+This template creates a Network Load Balancer (gateway) and a backend instance pool with autoscaling, using existing networking resources.
+
+Module structure:
+- networking: pass-through for existing network IDs
+- compute: instance configuration + instance pool
+- autoscaling: autoscaling configuration for the pool
+- nlb: network load balancer + listener + backend set
+- iam: IAM policy statements
+
+Architecture tree:
+gateway-instance-autoscale/
+- main.tf
+- variables.tf
+- outputs.tf
+- versions.tf
+- README.md
+- modules/
+  - networking/
+    - main.tf
+    - variables.tf
+    - outputs.tf
+  - compute/
+    - main.tf
+    - variables.tf
+    - outputs.tf
+  - autoscaling/
+    - main.tf
+    - variables.tf
+    - outputs.tf
+  - nlb/
+    - main.tf
+    - variables.tf
+    - outputs.tf
+  - iam/
+    - main.tf
+    - variables.tf
+    - outputs.tf
+
+Prerequisites:
+- OCI tenancy with permissions to create instance pools, autoscaling configs, and NLBs
+- Existing VCN and subnets
+
+IAM policy statements (default in variables.tf):
+- Allow service autoscaling to manage instance-pools in compartment id <compartment_ocid>
+- Allow service autoscaling to read metrics in compartment id <compartment_ocid>
+- Allow service compute to manage instance-family in compartment id <compartment_ocid>
+- Allow service compute to use subnets in compartment id <compartment_ocid>
+- Allow service compute to use network-security-groups in compartment id <compartment_ocid>
+- Allow service network-load-balancer to use subnets in compartment id <compartment_ocid>
+- Allow service network-load-balancer to use network-security-groups in compartment id <compartment_ocid>
+
+Usage:
+module "gateway_instance_autoscale" {
+  source = "./gateway-instance-autoscale"
+
+  compartment_id      = "ocid1.compartment.oc1..example"
+  vcn_id              = "ocid1.vcn.oc1..example"
+  nlb_subnet_id        = "ocid1.subnet.oc1..example"
+  instance_subnet_ids  = ["ocid1.subnet.oc1..example"]
+  availability_domains = ["Uocm:PHX-AD-1"]
+
+  instance_shape       = "VM.Standard.E4.Flex"
+  instance_ocpus       = 1
+  instance_memory_in_gbs = 8
+  instance_image_id    = "ocid1.image.oc1..example"
+  ssh_authorized_keys  = "ssh-rsa AAAA..."
+
+  placement_configurations = [
+    {
+      availability_domain = "Uocm:PHX-AD-1"
+      primary_subnet_id   = "ocid1.subnet.oc1..example"
+    }
+  ]
+}
+
+Outputs:
+- nlb_id
+- instance_pool_id
+- autoscaling_configuration_id
+- iam_policy_id

--- a/gateway-instance-autoscale/main.tf
+++ b/gateway-instance-autoscale/main.tf
@@ -1,0 +1,68 @@
+provider "oci" {}
+
+module "networking" {
+  source = "./modules/networking"
+
+  compartment_id      = var.compartment_id
+  vcn_id              = var.vcn_id
+  nlb_subnet_id        = var.nlb_subnet_id
+  instance_subnet_ids  = var.instance_subnet_ids
+  nlb_nsg_ids          = var.nlb_nsg_ids
+  instance_nsg_ids     = var.instance_nsg_ids
+}
+
+module "compute" {
+  source = "./modules/compute"
+
+  compartment_id              = var.compartment_id
+  instance_pool_name          = var.instance_pool_name
+  instance_configuration_name = var.instance_configuration_name
+  instance_subnet_ids         = module.networking.instance_subnet_ids
+  availability_domains        = var.availability_domains
+
+  shape             = var.instance_shape
+  ocpus             = var.instance_ocpus
+  memory_in_gbs     = var.instance_memory_in_gbs
+  image_id          = var.instance_image_id
+  ssh_authorized_keys = var.ssh_authorized_keys
+  user_data_base64  = var.user_data_base64
+
+  instance_nsg_ids   = module.networking.instance_nsg_ids
+  initial_size       = var.instance_pool_initial_size
+  placement_configurations = var.placement_configurations
+}
+
+module "autoscaling" {
+  source = "./modules/autoscaling"
+
+  compartment_id    = var.compartment_id
+  instance_pool_id  = module.compute.instance_pool_id
+
+  min_size          = var.autoscaling_min_size
+  max_size          = var.autoscaling_max_size
+  target_cpu        = var.autoscaling_target_cpu
+  scale_out_step    = var.autoscaling_scale_out_step
+  scale_in_step     = var.autoscaling_scale_in_step
+}
+
+module "nlb" {
+  source = "./modules/nlb"
+
+  compartment_id     = var.compartment_id
+  nlb_name           = var.nlb_name
+  nlb_subnet_id      = module.networking.nlb_subnet_id
+  nlb_nsg_ids        = module.networking.nlb_nsg_ids
+
+  listener_port      = var.listener_port
+  backend_port       = var.backend_port
+  backend_ips        = var.backend_ips
+}
+
+module "iam" {
+  source = "./modules/iam"
+
+  compartment_id     = var.compartment_id
+  policy_name        = var.policy_name
+  policy_description = var.policy_description
+  policy_statements  = var.policy_statements
+}

--- a/gateway-instance-autoscale/modules/autoscaling/main.tf
+++ b/gateway-instance-autoscale/modules/autoscaling/main.tf
@@ -1,0 +1,44 @@
+resource "oci_autoscaling_auto_scaling_configuration" "this" {
+  compartment_id = var.compartment_id
+  display_name   = "instance-pool-autoscaling"
+  is_enabled     = true
+
+  auto_scaling_resources {
+    id   = var.instance_pool_id
+    type = "instancePool"
+  }
+
+  policies {
+    display_name = "cpu-scaling-policy"
+    policy_type  = "threshold"
+    is_enabled   = true
+
+    capacity {
+      initial = var.min_size
+      min     = var.min_size
+      max     = var.max_size
+    }
+
+    rules {
+      display_name = "scale-out"
+      metric {
+        metric_type = "CPU_UTILIZATION"
+      }
+      action {
+        type  = "CHANGE_COUNT_BY"
+        value = var.scale_out_step
+      }
+    }
+
+    rules {
+      display_name = "scale-in"
+      metric {
+        metric_type = "CPU_UTILIZATION"
+      }
+      action {
+        type  = "CHANGE_COUNT_BY"
+        value = -1 * var.scale_in_step
+      }
+    }
+  }
+}

--- a/gateway-instance-autoscale/modules/autoscaling/outputs.tf
+++ b/gateway-instance-autoscale/modules/autoscaling/outputs.tf
@@ -1,0 +1,4 @@
+output "autoscaling_configuration_id" {
+  description = "Autoscaling configuration OCID."
+  value       = oci_autoscaling_auto_scaling_configuration.this.id
+}

--- a/gateway-instance-autoscale/modules/autoscaling/variables.tf
+++ b/gateway-instance-autoscale/modules/autoscaling/variables.tf
@@ -1,0 +1,34 @@
+variable "compartment_id" {
+  type        = string
+  description = "Compartment OCID."
+}
+
+variable "instance_pool_id" {
+  type        = string
+  description = "Instance pool OCID."
+}
+
+variable "min_size" {
+  type        = number
+  description = "Minimum size."
+}
+
+variable "max_size" {
+  type        = number
+  description = "Maximum size."
+}
+
+variable "target_cpu" {
+  type        = number
+  description = "Target CPU utilization."
+}
+
+variable "scale_out_step" {
+  type        = number
+  description = "Scale out step."
+}
+
+variable "scale_in_step" {
+  type        = number
+  description = "Scale in step."
+}

--- a/gateway-instance-autoscale/modules/compute/main.tf
+++ b/gateway-instance-autoscale/modules/compute/main.tf
@@ -1,0 +1,53 @@
+resource "oci_core_instance_configuration" "this" {
+  compartment_id = var.compartment_id
+  display_name   = var.instance_configuration_name
+
+  instance_details {
+    instance_type = "compute"
+
+    launch_details {
+      compartment_id = var.compartment_id
+      shape          = var.shape
+
+      dynamic "shape_config" {
+        for_each = var.shape_config_enabled ? [1] : []
+        content {
+          ocpus         = var.ocpus
+          memory_in_gbs = var.memory_in_gbs
+        }
+      }
+
+      source_details {
+        source_type = "image"
+        image_id    = var.image_id
+      }
+
+      create_vnic_details {
+        subnet_id        = var.instance_subnet_ids[0]
+        nsg_ids          = var.instance_nsg_ids
+        assign_public_ip = false
+      }
+
+      metadata = {
+        ssh_authorized_keys = var.ssh_authorized_keys
+        user_data           = var.user_data_base64
+      }
+    }
+  }
+}
+
+resource "oci_core_instance_pool" "this" {
+  compartment_id            = var.compartment_id
+  display_name              = var.instance_pool_name
+  instance_configuration_id = oci_core_instance_configuration.this.id
+  size                      = var.initial_size
+
+  dynamic "placement_configurations" {
+    for_each = var.placement_configurations
+    content {
+      availability_domain = placement_configurations.value.availability_domain
+      primary_subnet_id   = placement_configurations.value.primary_subnet_id
+      fault_domains       = try(placement_configurations.value.fault_domains, null)
+    }
+  }
+}

--- a/gateway-instance-autoscale/modules/compute/outputs.tf
+++ b/gateway-instance-autoscale/modules/compute/outputs.tf
@@ -1,0 +1,4 @@
+output "instance_pool_id" {
+  description = "Instance pool OCID."
+  value       = oci_core_instance_pool.this.id
+}

--- a/gateway-instance-autoscale/modules/compute/variables.tf
+++ b/gateway-instance-autoscale/modules/compute/variables.tf
@@ -1,0 +1,84 @@
+variable "compartment_id" {
+  type        = string
+  description = "Compartment OCID."
+}
+
+variable "instance_pool_name" {
+  type        = string
+  description = "Instance pool name."
+}
+
+variable "instance_configuration_name" {
+  type        = string
+  description = "Instance configuration name."
+}
+
+variable "instance_subnet_ids" {
+  type        = list(string)
+  description = "Instance subnet IDs."
+}
+
+variable "availability_domains" {
+  type        = list(string)
+  description = "Availability domains."
+}
+
+variable "shape" {
+  type        = string
+  description = "Compute shape."
+}
+
+variable "ocpus" {
+  type        = number
+  description = "OCPUs for flex shapes."
+  default     = 1
+}
+
+variable "memory_in_gbs" {
+  type        = number
+  description = "Memory in GB for flex shapes."
+  default     = 8
+}
+
+variable "shape_config_enabled" {
+  type        = bool
+  description = "Enable shape_config (for flex shapes)."
+  default     = true
+}
+
+variable "image_id" {
+  type        = string
+  description = "Image OCID."
+}
+
+variable "ssh_authorized_keys" {
+  type        = string
+  description = "SSH authorized keys."
+}
+
+variable "user_data_base64" {
+  type        = string
+  description = "Base64 user_data."
+  default     = ""
+}
+
+variable "instance_nsg_ids" {
+  type        = list(string)
+  description = "Instance NSG IDs."
+  default     = []
+}
+
+variable "initial_size" {
+  type        = number
+  description = "Initial instance pool size."
+  default     = 1
+}
+
+variable "placement_configurations" {
+  type = list(object({
+    availability_domain = string
+    primary_subnet_id   = string
+    fault_domains       = optional(list(string))
+  }))
+  description = "Placement configurations for the instance pool."
+}

--- a/gateway-instance-autoscale/modules/iam/main.tf
+++ b/gateway-instance-autoscale/modules/iam/main.tf
@@ -1,0 +1,6 @@
+resource "oci_identity_policy" "this" {
+  compartment_id = var.compartment_id
+  name           = var.policy_name
+  description    = var.policy_description
+  statements     = var.policy_statements
+}

--- a/gateway-instance-autoscale/modules/iam/outputs.tf
+++ b/gateway-instance-autoscale/modules/iam/outputs.tf
@@ -1,0 +1,4 @@
+output "policy_id" {
+  description = "IAM policy OCID."
+  value       = oci_identity_policy.this.id
+}

--- a/gateway-instance-autoscale/modules/iam/variables.tf
+++ b/gateway-instance-autoscale/modules/iam/variables.tf
@@ -1,0 +1,19 @@
+variable "compartment_id" {
+  type        = string
+  description = "Compartment OCID."
+}
+
+variable "policy_name" {
+  type        = string
+  description = "Policy name."
+}
+
+variable "policy_description" {
+  type        = string
+  description = "Policy description."
+}
+
+variable "policy_statements" {
+  type        = list(string)
+  description = "IAM policy statements."
+}

--- a/gateway-instance-autoscale/modules/networking/main.tf
+++ b/gateway-instance-autoscale/modules/networking/main.tf
@@ -1,0 +1,1 @@
+# Pass-through module for existing network resources (no API lookups).

--- a/gateway-instance-autoscale/modules/networking/outputs.tf
+++ b/gateway-instance-autoscale/modules/networking/outputs.tf
@@ -1,0 +1,24 @@
+output "vcn_id" {
+  description = "VCN OCID."
+  value       = var.vcn_id
+}
+
+output "nlb_subnet_id" {
+  description = "NLB subnet OCID."
+  value       = var.nlb_subnet_id
+}
+
+output "instance_subnet_ids" {
+  description = "Instance subnet OCIDs."
+  value       = var.instance_subnet_ids
+}
+
+output "nlb_nsg_ids" {
+  description = "NLB NSG OCIDs."
+  value       = var.nlb_nsg_ids
+}
+
+output "instance_nsg_ids" {
+  description = "Instance NSG OCIDs."
+  value       = var.instance_nsg_ids
+}

--- a/gateway-instance-autoscale/modules/networking/variables.tf
+++ b/gateway-instance-autoscale/modules/networking/variables.tf
@@ -1,0 +1,31 @@
+variable "compartment_id" {
+  type        = string
+  description = "Compartment OCID."
+}
+
+variable "vcn_id" {
+  type        = string
+  description = "VCN OCID."
+}
+
+variable "nlb_subnet_id" {
+  type        = string
+  description = "NLB subnet OCID."
+}
+
+variable "instance_subnet_ids" {
+  type        = list(string)
+  description = "Instance subnet OCIDs."
+}
+
+variable "nlb_nsg_ids" {
+  type        = list(string)
+  description = "NLB NSG OCIDs."
+  default     = []
+}
+
+variable "instance_nsg_ids" {
+  type        = list(string)
+  description = "Instance NSG OCIDs."
+  default     = []
+}

--- a/gateway-instance-autoscale/modules/nlb/main.tf
+++ b/gateway-instance-autoscale/modules/nlb/main.tf
@@ -1,0 +1,34 @@
+resource "oci_network_load_balancer_network_load_balancer" "this" {
+  compartment_id = var.compartment_id
+  display_name   = var.nlb_name
+  subnet_id      = var.nlb_subnet_id
+  is_private     = true
+}
+
+resource "oci_network_load_balancer_backend_set" "this" {
+  name                     = "backend-set"
+  network_load_balancer_id = oci_network_load_balancer_network_load_balancer.this.id
+  policy                   = "FIVE_TUPLE"
+
+  health_checker {
+    protocol = "TCP"
+    port     = var.backend_port
+  }
+}
+
+resource "oci_network_load_balancer_listener" "this" {
+  name                     = "listener"
+  network_load_balancer_id = oci_network_load_balancer_network_load_balancer.this.id
+  default_backend_set_name = oci_network_load_balancer_backend_set.this.name
+  port                     = var.listener_port
+  protocol                 = "TCP"
+}
+
+resource "oci_network_load_balancer_backend" "this" {
+  for_each                 = toset(var.backend_ips)
+  network_load_balancer_id = oci_network_load_balancer_network_load_balancer.this.id
+  backend_set_name         = oci_network_load_balancer_backend_set.this.name
+
+  ip_address = each.value
+  port       = var.backend_port
+}

--- a/gateway-instance-autoscale/modules/nlb/outputs.tf
+++ b/gateway-instance-autoscale/modules/nlb/outputs.tf
@@ -1,0 +1,4 @@
+output "nlb_id" {
+  description = "NLB OCID."
+  value       = oci_network_load_balancer_network_load_balancer.this.id
+}

--- a/gateway-instance-autoscale/modules/nlb/variables.tf
+++ b/gateway-instance-autoscale/modules/nlb/variables.tf
@@ -1,0 +1,36 @@
+variable "compartment_id" {
+  type        = string
+  description = "Compartment OCID."
+}
+
+variable "nlb_name" {
+  type        = string
+  description = "NLB name."
+}
+
+variable "nlb_subnet_id" {
+  type        = string
+  description = "NLB subnet OCID."
+}
+
+variable "nlb_nsg_ids" {
+  type        = list(string)
+  description = "NLB NSG OCIDs."
+  default     = []
+}
+
+variable "listener_port" {
+  type        = number
+  description = "Listener port."
+}
+
+variable "backend_port" {
+  type        = number
+  description = "Backend port."
+}
+
+variable "backend_ips" {
+  type        = list(string)
+  description = "Backend IPs for NLB."
+  default     = []
+}

--- a/gateway-instance-autoscale/outputs.tf
+++ b/gateway-instance-autoscale/outputs.tf
@@ -1,0 +1,19 @@
+output "nlb_id" {
+  description = "Network Load Balancer OCID."
+  value       = module.nlb.nlb_id
+}
+
+output "instance_pool_id" {
+  description = "Instance Pool OCID."
+  value       = module.compute.instance_pool_id
+}
+
+output "autoscaling_configuration_id" {
+  description = "Autoscaling configuration OCID."
+  value       = module.autoscaling.autoscaling_configuration_id
+}
+
+output "iam_policy_id" {
+  description = "IAM policy OCID."
+  value       = module.iam.policy_id
+}

--- a/gateway-instance-autoscale/plan.txt
+++ b/gateway-instance-autoscale/plan.txt
@@ -1,0 +1,539 @@
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  [32m+[0m create[0m
+
+Terraform will perform the following actions:
+
+[1m  # module.autoscaling.oci_autoscaling_auto_scaling_configuration.this[0m will be created
+[0m  [32m+[0m[0m resource "oci_autoscaling_auto_scaling_configuration" "this" {
+      [32m+[0m[0m compartment_id       = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+      [32m+[0m[0m cool_down_in_seconds = (known after apply)
+      [32m+[0m[0m defined_tags         = (known after apply)
+      [32m+[0m[0m display_name         = "instance-pool-autoscaling"
+      [32m+[0m[0m freeform_tags        = (known after apply)
+      [32m+[0m[0m id                   = (known after apply)
+      [32m+[0m[0m is_enabled           = true
+      [32m+[0m[0m max_resource_count   = (known after apply)
+      [32m+[0m[0m min_resource_count   = (known after apply)
+      [32m+[0m[0m time_created         = (known after apply)
+
+      [32m+[0m[0m auto_scaling_resources {
+          [32m+[0m[0m id   = (known after apply)
+          [32m+[0m[0m type = "instancePool"
+        }
+
+      [32m+[0m[0m policies {
+          [32m+[0m[0m display_name = "cpu-scaling-policy"
+          [32m+[0m[0m id           = (known after apply)
+          [32m+[0m[0m is_enabled   = true
+          [32m+[0m[0m policy_type  = "threshold"
+          [32m+[0m[0m time_created = (known after apply)
+
+          [32m+[0m[0m capacity {
+              [32m+[0m[0m initial = 1
+              [32m+[0m[0m max     = 3
+              [32m+[0m[0m min     = 1
+            }
+
+          [32m+[0m[0m rules {
+              [32m+[0m[0m display_name = "scale-in"
+              [32m+[0m[0m id           = (known after apply)
+
+              [32m+[0m[0m action {
+                  [32m+[0m[0m type  = "CHANGE_COUNT_BY"
+                  [32m+[0m[0m value = -1
+                }
+
+              [32m+[0m[0m metric {
+                  [32m+[0m[0m metric_source    = "COMPUTE_AGENT"
+                  [32m+[0m[0m metric_type      = "CPU_UTILIZATION"
+                  [32m+[0m[0m pending_duration = "PT3M"
+                }
+            }
+          [32m+[0m[0m rules {
+              [32m+[0m[0m display_name = "scale-out"
+              [32m+[0m[0m id           = (known after apply)
+
+              [32m+[0m[0m action {
+                  [32m+[0m[0m type  = "CHANGE_COUNT_BY"
+                  [32m+[0m[0m value = 1
+                }
+
+              [32m+[0m[0m metric {
+                  [32m+[0m[0m metric_source    = "COMPUTE_AGENT"
+                  [32m+[0m[0m metric_type      = "CPU_UTILIZATION"
+                  [32m+[0m[0m pending_duration = "PT3M"
+                }
+            }
+        }
+    }
+
+[1m  # module.compute.oci_core_instance_configuration.this[0m will be created
+[0m  [32m+[0m[0m resource "oci_core_instance_configuration" "this" {
+      [32m+[0m[0m compartment_id  = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+      [32m+[0m[0m deferred_fields = (known after apply)
+      [32m+[0m[0m defined_tags    = (known after apply)
+      [32m+[0m[0m display_name    = "gateway-instance-config"
+      [32m+[0m[0m freeform_tags   = (known after apply)
+      [32m+[0m[0m id              = (known after apply)
+      [32m+[0m[0m instance_id     = (known after apply)
+      [32m+[0m[0m source          = (known after apply)
+      [32m+[0m[0m time_created    = (known after apply)
+
+      [32m+[0m[0m instance_details {
+          [32m+[0m[0m instance_type = "compute"
+
+          [32m+[0m[0m launch_details {
+              [32m+[0m[0m availability_domain                 = (known after apply)
+              [32m+[0m[0m capacity_reservation_id             = (known after apply)
+              [32m+[0m[0m cluster_placement_group_id          = (known after apply)
+              [32m+[0m[0m compartment_id                      = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+              [32m+[0m[0m compute_cluster_id                  = (known after apply)
+              [32m+[0m[0m dedicated_vm_host_id                = (known after apply)
+              [32m+[0m[0m defined_tags                        = (known after apply)
+              [32m+[0m[0m display_name                        = (known after apply)
+              [32m+[0m[0m extended_metadata                   = (known after apply)
+              [32m+[0m[0m fault_domain                        = (known after apply)
+              [32m+[0m[0m freeform_tags                       = (known after apply)
+              [32m+[0m[0m ipxe_script                         = (known after apply)
+              [32m+[0m[0m is_ai_enterprise_enabled            = (known after apply)
+              [32m+[0m[0m is_pv_encryption_in_transit_enabled = (known after apply)
+              [32m+[0m[0m launch_mode                         = (known after apply)
+              [32m+[0m[0m metadata                            = {
+                  [32m+[0m[0m "ssh_authorized_keys" = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD"
+                  [32m+[0m[0m "user_data"           = ""
+                }
+              [32m+[0m[0m preferred_maintenance_action        = (known after apply)
+              [32m+[0m[0m security_attributes                 = (known after apply)
+              [32m+[0m[0m shape                               = "VM.Standard.E4.Flex"
+
+              [32m+[0m[0m create_vnic_details {
+                  [32m+[0m[0m assign_ipv6ip             = (known after apply)
+                  [32m+[0m[0m assign_private_dns_record = true
+                  [32m+[0m[0m assign_public_ip          = false
+                  [32m+[0m[0m defined_tags              = (known after apply)
+                  [32m+[0m[0m display_name              = (known after apply)
+                  [32m+[0m[0m freeform_tags             = (known after apply)
+                  [32m+[0m[0m hostname_label            = (known after apply)
+                  [32m+[0m[0m private_ip                = (known after apply)
+                  [32m+[0m[0m private_ip_id             = (known after apply)
+                  [32m+[0m[0m security_attributes       = (known after apply)
+                  [32m+[0m[0m skip_source_dest_check    = (known after apply)
+                  [32m+[0m[0m subnet_cidr               = (known after apply)
+                  [32m+[0m[0m subnet_id                 = "ocid1.subnet.oc1..dryrun00000000000000000000000000000000000000000000000001"
+                }
+
+              [32m+[0m[0m shape_config {
+                  [32m+[0m[0m baseline_ocpu_utilization = (known after apply)
+                  [32m+[0m[0m memory_in_gbs             = 8
+                  [32m+[0m[0m nvmes                     = (known after apply)
+                  [32m+[0m[0m ocpus                     = 1
+                  [32m+[0m[0m resource_management       = (known after apply)
+                  [32m+[0m[0m vcpus                     = (known after apply)
+                }
+
+              [32m+[0m[0m source_details {
+                  [32m+[0m[0m boot_volume_id          = (known after apply)
+                  [32m+[0m[0m boot_volume_size_in_gbs = (known after apply)
+                  [32m+[0m[0m boot_volume_vpus_per_gb = (known after apply)
+                  [32m+[0m[0m image_id                = "ocid1.image.oc1..dryrun00000000000000000000000000000000000000000000000000"
+                  [32m+[0m[0m kms_key_id              = (known after apply)
+                  [32m+[0m[0m source_type             = "image"
+                }
+            }
+        }
+    }
+
+[1m  # module.compute.oci_core_instance_pool.this[0m will be created
+[0m  [32m+[0m[0m resource "oci_core_instance_pool" "this" {
+      [32m+[0m[0m actual_size                     = (known after apply)
+      [32m+[0m[0m compartment_id                  = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+      [32m+[0m[0m defined_tags                    = (known after apply)
+      [32m+[0m[0m display_name                    = "gateway-instance-pool"
+      [32m+[0m[0m freeform_tags                   = (known after apply)
+      [32m+[0m[0m id                              = (known after apply)
+      [32m+[0m[0m instance_configuration_id       = (known after apply)
+      [32m+[0m[0m instance_display_name_formatter = (known after apply)
+      [32m+[0m[0m instance_hostname_formatter     = (known after apply)
+      [32m+[0m[0m size                            = 1
+      [32m+[0m[0m state                           = (known after apply)
+      [32m+[0m[0m time_created                    = (known after apply)
+
+      [32m+[0m[0m placement_configurations {
+          [32m+[0m[0m availability_domain = "Uocm:PHX-AD-1"
+          [32m+[0m[0m fault_domains       = (known after apply)
+          [32m+[0m[0m primary_subnet_id   = "ocid1.subnet.oc1..dryrun00000000000000000000000000000000000000000000000001"
+        }
+    }
+
+[1m  # module.iam.oci_identity_policy.this[0m will be created
+[0m  [32m+[0m[0m resource "oci_identity_policy" "this" {
+      [32m+[0m[0m ETag           = (known after apply)
+      [32m+[0m[0m compartment_id = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+      [32m+[0m[0m defined_tags   = (known after apply)
+      [32m+[0m[0m description    = "IAM policies required for NLB + instance pool + autoscaling."
+      [32m+[0m[0m freeform_tags  = (known after apply)
+      [32m+[0m[0m id             = (known after apply)
+      [32m+[0m[0m inactive_state = (known after apply)
+      [32m+[0m[0m lastUpdateETag = (known after apply)
+      [32m+[0m[0m name           = "gateway-instance-autoscale-policy"
+      [32m+[0m[0m policyHash     = (known after apply)
+      [32m+[0m[0m state          = (known after apply)
+      [32m+[0m[0m statements     = [
+          [32m+[0m[0m "Allow service autoscaling to manage instance-pools in compartment id <compartment_ocid>",
+          [32m+[0m[0m "Allow service autoscaling to read metrics in compartment id <compartment_ocid>",
+          [32m+[0m[0m "Allow service compute to manage instance-family in compartment id <compartment_ocid>",
+          [32m+[0m[0m "Allow service compute to use subnets in compartment id <compartment_ocid>",
+          [32m+[0m[0m "Allow service compute to use network-security-groups in compartment id <compartment_ocid>",
+          [32m+[0m[0m "Allow service network-load-balancer to use subnets in compartment id <compartment_ocid>",
+          [32m+[0m[0m "Allow service network-load-balancer to use network-security-groups in compartment id <compartment_ocid>",
+        ]
+      [32m+[0m[0m time_created   = (known after apply)
+      [32m+[0m[0m version_date   = (known after apply)
+    }
+
+[1m  # module.nlb.oci_network_load_balancer_backend_set.this[0m will be created
+[0m  [32m+[0m[0m resource "oci_network_load_balancer_backend_set" "this" {
+      [32m+[0m[0m are_operationally_active_backends_preferred = (known after apply)
+      [32m+[0m[0m backends                                    = (known after apply)
+      [32m+[0m[0m id                                          = (known after apply)
+      [32m+[0m[0m ip_version                                  = (known after apply)
+      [32m+[0m[0m is_fail_open                                = (known after apply)
+      [32m+[0m[0m is_instant_failover_enabled                 = (known after apply)
+      [32m+[0m[0m is_instant_failover_tcp_reset_enabled       = (known after apply)
+      [32m+[0m[0m is_preserve_source                          = (known after apply)
+      [32m+[0m[0m name                                        = "backend-set"
+      [32m+[0m[0m network_load_balancer_id                    = (known after apply)
+      [32m+[0m[0m policy                                      = "FIVE_TUPLE"
+
+      [32m+[0m[0m health_checker {
+          [32m+[0m[0m interval_in_millis  = (known after apply)
+          [32m+[0m[0m port                = 8080
+          [32m+[0m[0m protocol            = "TCP"
+          [32m+[0m[0m request_data        = (known after apply)
+          [32m+[0m[0m response_body_regex = (known after apply)
+          [32m+[0m[0m response_data       = (known after apply)
+          [32m+[0m[0m retries             = (known after apply)
+          [32m+[0m[0m return_code         = (known after apply)
+          [32m+[0m[0m timeout_in_millis   = (known after apply)
+          [32m+[0m[0m url_path            = (known after apply)
+        }
+    }
+
+[1m  # module.nlb.oci_network_load_balancer_listener.this[0m will be created
+[0m  [32m+[0m[0m resource "oci_network_load_balancer_listener" "this" {
+      [32m+[0m[0m default_backend_set_name = "backend-set"
+      [32m+[0m[0m id                       = (known after apply)
+      [32m+[0m[0m ip_version               = (known after apply)
+      [32m+[0m[0m is_ppv2enabled           = (known after apply)
+      [32m+[0m[0m l3ip_idle_timeout        = (known after apply)
+      [32m+[0m[0m name                     = "listener"
+      [32m+[0m[0m network_load_balancer_id = (known after apply)
+      [32m+[0m[0m port                     = 80
+      [32m+[0m[0m protocol                 = "TCP"
+      [32m+[0m[0m tcp_idle_timeout         = (known after apply)
+      [32m+[0m[0m udp_idle_timeout         = (known after apply)
+    }
+
+[1m  # module.nlb.oci_network_load_balancer_network_load_balancer.this[0m will be created
+[0m  [32m+[0m[0m resource "oci_network_load_balancer_network_load_balancer" "this" {
+      [32m+[0m[0m compartment_id                 = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+      [32m+[0m[0m defined_tags                   = (known after apply)
+      [32m+[0m[0m display_name                   = "gateway-nlb"
+      [32m+[0m[0m freeform_tags                  = (known after apply)
+      [32m+[0m[0m id                             = (known after apply)
+      [32m+[0m[0m ip_addresses                   = (known after apply)
+      [32m+[0m[0m is_preserve_source_destination = (known after apply)
+      [32m+[0m[0m is_private                     = true
+      [32m+[0m[0m is_symmetric_hash_enabled      = (known after apply)
+      [32m+[0m[0m lifecycle_details              = (known after apply)
+      [32m+[0m[0m nlb_ip_version                 = (known after apply)
+      [32m+[0m[0m security_attributes            = (known after apply)
+      [32m+[0m[0m state                          = (known after apply)
+      [32m+[0m[0m subnet_id                      = "ocid1.subnet.oc1..dryrun00000000000000000000000000000000000000000000000000"
+      [32m+[0m[0m system_tags                    = (known after apply)
+      [32m+[0m[0m time_created                   = (known after apply)
+      [32m+[0m[0m time_updated                   = (known after apply)
+    }
+
+[1mPlan:[0m 7 to add, 0 to change, 0 to destroy.
+[0m
+Changes to Outputs:
+  [32m+[0m[0m autoscaling_configuration_id = (known after apply)
+  [32m+[0m[0m iam_policy_id                = (known after apply)
+  [32m+[0m[0m instance_pool_id             = (known after apply)
+  [32m+[0m[0m nlb_id                       = (known after apply)
+[90m
+─────────────────────────────────────────────────────────────────────────────[0m
+
+Saved the plan to: plan.out
+
+To perform exactly these actions, run the following command to apply:
+    terraform apply "plan.out"
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # module.autoscaling.oci_autoscaling_auto_scaling_configuration.this will be created
+  + resource "oci_autoscaling_auto_scaling_configuration" "this" {
+      + compartment_id       = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+      + cool_down_in_seconds = (known after apply)
+      + defined_tags         = (known after apply)
+      + display_name         = "instance-pool-autoscaling"
+      + freeform_tags        = (known after apply)
+      + id                   = (known after apply)
+      + is_enabled           = true
+      + max_resource_count   = (known after apply)
+      + min_resource_count   = (known after apply)
+      + time_created         = (known after apply)
+
+      + auto_scaling_resources {
+          + id   = (known after apply)
+          + type = "instancePool"
+        }
+
+      + policies {
+          + display_name = "cpu-scaling-policy"
+          + id           = (known after apply)
+          + is_enabled   = true
+          + policy_type  = "threshold"
+          + time_created = (known after apply)
+
+          + capacity {
+              + initial = 1
+              + max     = 3
+              + min     = 1
+            }
+
+          + rules {
+              + display_name = "scale-in"
+              + id           = (known after apply)
+
+              + action {
+                  + type  = "CHANGE_COUNT_BY"
+                  + value = -1
+                }
+
+              + metric {
+                  + metric_source    = "COMPUTE_AGENT"
+                  + metric_type      = "CPU_UTILIZATION"
+                  + pending_duration = "PT3M"
+                }
+            }
+          + rules {
+              + display_name = "scale-out"
+              + id           = (known after apply)
+
+              + action {
+                  + type  = "CHANGE_COUNT_BY"
+                  + value = 1
+                }
+
+              + metric {
+                  + metric_source    = "COMPUTE_AGENT"
+                  + metric_type      = "CPU_UTILIZATION"
+                  + pending_duration = "PT3M"
+                }
+            }
+        }
+    }
+
+  # module.compute.oci_core_instance_configuration.this will be created
+  + resource "oci_core_instance_configuration" "this" {
+      + compartment_id  = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+      + deferred_fields = (known after apply)
+      + defined_tags    = (known after apply)
+      + display_name    = "gateway-instance-config"
+      + freeform_tags   = (known after apply)
+      + id              = (known after apply)
+      + instance_id     = (known after apply)
+      + source          = (known after apply)
+      + time_created    = (known after apply)
+
+      + instance_details {
+          + instance_type = "compute"
+
+          + launch_details {
+              + availability_domain                 = (known after apply)
+              + capacity_reservation_id             = (known after apply)
+              + cluster_placement_group_id          = (known after apply)
+              + compartment_id                      = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+              + compute_cluster_id                  = (known after apply)
+              + dedicated_vm_host_id                = (known after apply)
+              + defined_tags                        = (known after apply)
+              + display_name                        = (known after apply)
+              + extended_metadata                   = (known after apply)
+              + fault_domain                        = (known after apply)
+              + freeform_tags                       = (known after apply)
+              + ipxe_script                         = (known after apply)
+              + is_ai_enterprise_enabled            = (known after apply)
+              + is_pv_encryption_in_transit_enabled = (known after apply)
+              + launch_mode                         = (known after apply)
+              + metadata                            = {
+                  + "ssh_authorized_keys" = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD"
+                  + "user_data"           = ""
+                }
+              + preferred_maintenance_action        = (known after apply)
+              + security_attributes                 = (known after apply)
+              + shape                               = "VM.Standard.E4.Flex"
+
+              + create_vnic_details {
+                  + assign_ipv6ip             = (known after apply)
+                  + assign_private_dns_record = true
+                  + assign_public_ip          = false
+                  + defined_tags              = (known after apply)
+                  + display_name              = (known after apply)
+                  + freeform_tags             = (known after apply)
+                  + hostname_label            = (known after apply)
+                  + private_ip                = (known after apply)
+                  + private_ip_id             = (known after apply)
+                  + security_attributes       = (known after apply)
+                  + skip_source_dest_check    = (known after apply)
+                  + subnet_cidr               = (known after apply)
+                  + subnet_id                 = "ocid1.subnet.oc1..dryrun00000000000000000000000000000000000000000000000001"
+                }
+
+              + shape_config {
+                  + baseline_ocpu_utilization = (known after apply)
+                  + memory_in_gbs             = 8
+                  + nvmes                     = (known after apply)
+                  + ocpus                     = 1
+                  + resource_management       = (known after apply)
+                  + vcpus                     = (known after apply)
+                }
+
+              + source_details {
+                  + boot_volume_id          = (known after apply)
+                  + boot_volume_size_in_gbs = (known after apply)
+                  + boot_volume_vpus_per_gb = (known after apply)
+                  + image_id                = "ocid1.image.oc1..dryrun00000000000000000000000000000000000000000000000000"
+                  + kms_key_id              = (known after apply)
+                  + source_type             = "image"
+                }
+            }
+        }
+    }
+
+  # module.compute.oci_core_instance_pool.this will be created
+  + resource "oci_core_instance_pool" "this" {
+      + actual_size                     = (known after apply)
+      + compartment_id                  = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+      + defined_tags                    = (known after apply)
+      + display_name                    = "gateway-instance-pool"
+      + freeform_tags                   = (known after apply)
+      + id                              = (known after apply)
+      + instance_configuration_id       = (known after apply)
+      + instance_display_name_formatter = (known after apply)
+      + instance_hostname_formatter     = (known after apply)
+      + size                            = 1
+      + state                           = (known after apply)
+      + time_created                    = (known after apply)
+
+      + placement_configurations {
+          + availability_domain = "Uocm:PHX-AD-1"
+          + fault_domains       = (known after apply)
+          + primary_subnet_id   = "ocid1.subnet.oc1..dryrun00000000000000000000000000000000000000000000000001"
+        }
+    }
+
+  # module.iam.oci_identity_policy.this will be created
+  + resource "oci_identity_policy" "this" {
+      + ETag           = (known after apply)
+      + compartment_id = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+      + defined_tags   = (known after apply)
+      + description    = "IAM policies required for NLB + instance pool + autoscaling."
+      + freeform_tags  = (known after apply)
+      + id             = (known after apply)
+      + inactive_state = (known after apply)
+      + lastUpdateETag = (known after apply)
+      + name           = "gateway-instance-autoscale-policy"
+      + policyHash     = (known after apply)
+      + state          = (known after apply)
+      + statements     = [
+          + "Allow service autoscaling to manage instance-pools in compartment id <compartment_ocid>",
+          + "Allow service autoscaling to read metrics in compartment id <compartment_ocid>",
+          + "Allow service compute to manage instance-family in compartment id <compartment_ocid>",
+          + "Allow service compute to use subnets in compartment id <compartment_ocid>",
+          + "Allow service compute to use network-security-groups in compartment id <compartment_ocid>",
+          + "Allow service network-load-balancer to use subnets in compartment id <compartment_ocid>",
+          + "Allow service network-load-balancer to use network-security-groups in compartment id <compartment_ocid>",
+        ]
+      + time_created   = (known after apply)
+      + version_date   = (known after apply)
+    }
+
+  # module.nlb.oci_network_load_balancer_backend_set.this will be created
+  + resource "oci_network_load_balancer_backend_set" "this" {
+      + are_operationally_active_backends_preferred = (known after apply)
+      + backends                                    = (known after apply)
+      + id                                          = (known after apply)
+      + ip_version                                  = (known after apply)
+      + is_fail_open                                = (known after apply)
+      + is_instant_failover_enabled                 = (known after apply)
+      + is_instant_failover_tcp_reset_enabled       = (known after apply)
+      + is_preserve_source                          = (known after apply)
+      + name                                        = "backend-set"
+      + network_load_balancer_id                    = (known after apply)
+      + policy                                      = "FIVE_TUPLE"
+
+      + health_checker {
+          + interval_in_millis  = (known after apply)
+          + port                = 8080
+          + protocol            = "TCP"
+          + request_data        = (known after apply)
+          + response_body_regex = (known after apply)
+          + response_data       = (known after apply)
+          + retries             = (known after apply)
+          + return_code         = (known after apply)
+          + timeout_in_millis   = (known after apply)
+          + url_path            = (known after apply)
+        }
+    }
+
+  # module.nlb.oci_network_load_balancer_listener.this will be created
+  + resource "oci_network_load_balancer_listener" "this" {
+      + default_backend_set_name = "backend-set"
+      + id                       = (known after apply)
+      + ip_version               = (known after apply)
+      + is_ppv2enabled           = (known after apply)
+      + l3ip_idle_timeout        = (known after apply)
+      + name                     = "listener"
+      + network_load_balancer_id = (known after apply)
+      + port                     = 80
+      + protocol                 = "TCP"
+      + tcp_idle_timeout         = (known after apply)
+      + udp_idle_timeout         = (known after apply)
+    }
+
+  # module.nlb.oci_network_load_balancer_network_load_balancer.this will be created
+  + resource "oci_network_load_balancer_network_load_balancer" "this" {
+      + compartment_id                 = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+      + defined_tags                   = (known after apply)
+      + display_name                   = "gateway-nlb"
+      + freeform_tags                  = (known after apply)
+      + id                             = (known after apply)
+      + ip_addresses                   = (known after apply)
+      + is_preserve_source_destination = (known after apply)
+      + is_private                     = true
+      + is_symmetric_hash_enabled      = (known after apply)
+      + lifecycle_details              = (known after apply)
+      + nlb_ip_version                 = (known after apply)
+      + security_attributes            = (known after apply)
+      + state                          = (known after apply)
+      + subnet_id                      = "ocid1.subnet.oc1..dryrun00000000000000000000000000000000000000000000000000"
+      + system_tags                    = (known after apply)
+      + time_created                   = (known after apply)
+      + time_updated                   = (known after apply)
+    }
+
+Plan: 7 to add, 0 to change, 0 to destroy.
+
+Changes to Outputs:
+  + autoscaling_configuration_id = (known after apply)
+  + iam_policy_id                = (known after apply)
+  + instance_pool_id             = (known after apply)
+  + nlb_id                       = (known after apply)

--- a/gateway-instance-autoscale/variables.tf
+++ b/gateway-instance-autoscale/variables.tf
@@ -1,0 +1,176 @@
+variable "compartment_id" {
+  type        = string
+  description = "Compartment OCID."
+}
+
+variable "vcn_id" {
+  type        = string
+  description = "Existing VCN OCID."
+}
+
+variable "nlb_subnet_id" {
+  type        = string
+  description = "Subnet OCID for the Network Load Balancer."
+}
+
+variable "instance_subnet_ids" {
+  type        = list(string)
+  description = "Subnets for the instance pool."
+}
+
+variable "nlb_nsg_ids" {
+  type        = list(string)
+  description = "NSG OCIDs for the NLB."
+  default     = []
+}
+
+variable "instance_nsg_ids" {
+  type        = list(string)
+  description = "NSG OCIDs for instances."
+  default     = []
+}
+
+variable "availability_domains" {
+  type        = list(string)
+  description = "Availability domains for the instance pool placement."
+}
+
+variable "instance_pool_name" {
+  type        = string
+  description = "Instance pool name."
+  default     = "gateway-instance-pool"
+}
+
+variable "instance_configuration_name" {
+  type        = string
+  description = "Instance configuration name."
+  default     = "gateway-instance-config"
+}
+
+variable "instance_pool_initial_size" {
+  type        = number
+  description = "Initial size of the instance pool."
+  default     = 1
+}
+
+variable "instance_shape" {
+  type        = string
+  description = "Compute shape (e.g., VM.Standard.E4.Flex)."
+}
+
+variable "instance_ocpus" {
+  type        = number
+  description = "OCPUs for flex shapes."
+  default     = 1
+}
+
+variable "instance_memory_in_gbs" {
+  type        = number
+  description = "Memory (GB) for flex shapes."
+  default     = 8
+}
+
+variable "instance_image_id" {
+  type        = string
+  description = "Image OCID for instances."
+}
+
+variable "ssh_authorized_keys" {
+  type        = string
+  description = "SSH public keys."
+}
+
+variable "user_data_base64" {
+  type        = string
+  description = "Optional user_data (base64 encoded)."
+  default     = ""
+}
+
+variable "autoscaling_min_size" {
+  type        = number
+  description = "Autoscaling min size."
+  default     = 1
+}
+
+variable "autoscaling_max_size" {
+  type        = number
+  description = "Autoscaling max size."
+  default     = 3
+}
+
+variable "autoscaling_target_cpu" {
+  type        = number
+  description = "Target CPU utilization percentage."
+  default     = 70
+}
+
+variable "autoscaling_scale_out_step" {
+  type        = number
+  description = "Scale out by N instances."
+  default     = 1
+}
+
+variable "autoscaling_scale_in_step" {
+  type        = number
+  description = "Scale in by N instances."
+  default     = 1
+}
+
+variable "nlb_name" {
+  type        = string
+  description = "Network Load Balancer name."
+  default     = "gateway-nlb"
+}
+
+variable "listener_port" {
+  type        = number
+  description = "Listener port for NLB."
+  default     = 80
+}
+
+variable "backend_port" {
+  type        = number
+  description = "Backend port for instances."
+  default     = 8080
+}
+
+variable "backend_ips" {
+  type        = list(string)
+  description = "Backend IP addresses for NLB (leave empty to manage externally)."
+  default     = []
+}
+
+variable "policy_name" {
+  type        = string
+  description = "IAM policy name."
+  default     = "gateway-instance-autoscale-policy"
+}
+
+variable "policy_description" {
+  type        = string
+  description = "IAM policy description."
+  default     = "IAM policies required for NLB + instance pool + autoscaling."
+}
+
+variable "policy_statements" {
+  type        = list(string)
+  description = "IAM policy statements."
+  default = [
+    "Allow service autoscaling to manage instance-pools in compartment id <compartment_ocid>",
+    "Allow service autoscaling to read metrics in compartment id <compartment_ocid>",
+    "Allow service compute to manage instance-family in compartment id <compartment_ocid>",
+    "Allow service compute to use subnets in compartment id <compartment_ocid>",
+    "Allow service compute to use network-security-groups in compartment id <compartment_ocid>",
+    "Allow service network-load-balancer to use subnets in compartment id <compartment_ocid>",
+    "Allow service network-load-balancer to use network-security-groups in compartment id <compartment_ocid>"
+  ]
+}
+
+variable "placement_configurations" {
+  type = list(object({
+    availability_domain = string
+    primary_subnet_id   = string
+    fault_domains       = optional(list(string))
+  }))
+  description = "Placement configurations for the instance pool."
+}

--- a/gateway-instance-autoscale/versions.tf
+++ b/gateway-instance-autoscale/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = ">= 5.0.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds a new module-structured OCI Terraform template: `gateway-instance-autoscale`.

## Module Structure
gateway-instance-autoscale/.terraform.lock.hcl
gateway-instance-autoscale/.terraform/modules/modules.json
gateway-instance-autoscale/.terraform/providers/registry.terraform.io/hashicorp/oci/8.7.0/darwin_arm64/terraform-provider-oci_v8.7.0
gateway-instance-autoscale/.terraform/providers/registry.terraform.io/oracle/oci/8.7.0/darwin_arm64/terraform-provider-oci_v8.7.0
gateway-instance-autoscale/README.md
gateway-instance-autoscale/main.tf
gateway-instance-autoscale/modules/autoscaling/main.tf
gateway-instance-autoscale/modules/autoscaling/outputs.tf
gateway-instance-autoscale/modules/autoscaling/variables.tf
gateway-instance-autoscale/modules/compute/main.tf
gateway-instance-autoscale/modules/compute/outputs.tf
gateway-instance-autoscale/modules/compute/variables.tf
gateway-instance-autoscale/modules/iam/main.tf
gateway-instance-autoscale/modules/iam/outputs.tf
gateway-instance-autoscale/modules/iam/variables.tf
gateway-instance-autoscale/modules/networking/main.tf
gateway-instance-autoscale/modules/networking/outputs.tf
gateway-instance-autoscale/modules/networking/variables.tf
gateway-instance-autoscale/modules/nlb/main.tf
gateway-instance-autoscale/modules/nlb/outputs.tf
gateway-instance-autoscale/modules/nlb/variables.tf
gateway-instance-autoscale/outputs.tf
gateway-instance-autoscale/plan.txt
gateway-instance-autoscale/variables.tf
gateway-instance-autoscale/versions.tf

## Terraform Plan
```

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  [32m+[0m create[0m

Terraform will perform the following actions:

[1m  # module.autoscaling.oci_autoscaling_auto_scaling_configuration.this[0m will be created
[0m  [32m+[0m[0m resource "oci_autoscaling_auto_scaling_configuration" "this" {
      [32m+[0m[0m compartment_id       = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
      [32m+[0m[0m cool_down_in_seconds = (known after apply)
      [32m+[0m[0m defined_tags         = (known after apply)
      [32m+[0m[0m display_name         = "instance-pool-autoscaling"
      [32m+[0m[0m freeform_tags        = (known after apply)
      [32m+[0m[0m id                   = (known after apply)
      [32m+[0m[0m is_enabled           = true
      [32m+[0m[0m max_resource_count   = (known after apply)
      [32m+[0m[0m min_resource_count   = (known after apply)
      [32m+[0m[0m time_created         = (known after apply)

      [32m+[0m[0m auto_scaling_resources {
          [32m+[0m[0m id   = (known after apply)
          [32m+[0m[0m type = "instancePool"
        }

      [32m+[0m[0m policies {
          [32m+[0m[0m display_name = "cpu-scaling-policy"
          [32m+[0m[0m id           = (known after apply)
          [32m+[0m[0m is_enabled   = true
          [32m+[0m[0m policy_type  = "threshold"
          [32m+[0m[0m time_created = (known after apply)

          [32m+[0m[0m capacity {
              [32m+[0m[0m initial = 1
              [32m+[0m[0m max     = 3
              [32m+[0m[0m min     = 1
            }

          [32m+[0m[0m rules {
              [32m+[0m[0m display_name = "scale-in"
              [32m+[0m[0m id           = (known after apply)

              [32m+[0m[0m action {
                  [32m+[0m[0m type  = "CHANGE_COUNT_BY"
                  [32m+[0m[0m value = -1
                }

              [32m+[0m[0m metric {
                  [32m+[0m[0m metric_source    = "COMPUTE_AGENT"
                  [32m+[0m[0m metric_type      = "CPU_UTILIZATION"
                  [32m+[0m[0m pending_duration = "PT3M"
                }
            }
          [32m+[0m[0m rules {
              [32m+[0m[0m display_name = "scale-out"
              [32m+[0m[0m id           = (known after apply)

              [32m+[0m[0m action {
                  [32m+[0m[0m type  = "CHANGE_COUNT_BY"
                  [32m+[0m[0m value = 1
                }

              [32m+[0m[0m metric {
                  [32m+[0m[0m metric_source    = "COMPUTE_AGENT"
                  [32m+[0m[0m metric_type      = "CPU_UTILIZATION"
                  [32m+[0m[0m pending_duration = "PT3M"
                }
            }
        }
    }

[1m  # module.compute.oci_core_instance_configuration.this[0m will be created
[0m  [32m+[0m[0m resource "oci_core_instance_configuration" "this" {
      [32m+[0m[0m compartment_id  = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
      [32m+[0m[0m deferred_fields = (known after apply)
      [32m+[0m[0m defined_tags    = (known after apply)
      [32m+[0m[0m display_name    = "gateway-instance-config"
      [32m+[0m[0m freeform_tags   = (known after apply)
      [32m+[0m[0m id              = (known after apply)
      [32m+[0m[0m instance_id     = (known after apply)
      [32m+[0m[0m source          = (known after apply)
      [32m+[0m[0m time_created    = (known after apply)

      [32m+[0m[0m instance_details {
          [32m+[0m[0m instance_type = "compute"

          [32m+[0m[0m launch_details {
              [32m+[0m[0m availability_domain                 = (known after apply)
              [32m+[0m[0m capacity_reservation_id             = (known after apply)
              [32m+[0m[0m cluster_placement_group_id          = (known after apply)
              [32m+[0m[0m compartment_id                      = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
              [32m+[0m[0m compute_cluster_id                  = (known after apply)
              [32m+[0m[0m dedicated_vm_host_id                = (known after apply)
              [32m+[0m[0m defined_tags                        = (known after apply)
              [32m+[0m[0m display_name                        = (known after apply)
              [32m+[0m[0m extended_metadata                   = (known after apply)
              [32m+[0m[0m fault_domain                        = (known after apply)
              [32m+[0m[0m freeform_tags                       = (known after apply)
              [32m+[0m[0m ipxe_script                         = (known after apply)
              [32m+[0m[0m is_ai_enterprise_enabled            = (known after apply)
              [32m+[0m[0m is_pv_encryption_in_transit_enabled = (known after apply)
              [32m+[0m[0m launch_mode                         = (known after apply)
              [32m+[0m[0m metadata                            = {
                  [32m+[0m[0m "ssh_authorized_keys" = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD"
                  [32m+[0m[0m "user_data"           = ""
                }
              [32m+[0m[0m preferred_maintenance_action        = (known after apply)
              [32m+[0m[0m security_attributes                 = (known after apply)
              [32m+[0m[0m shape                               = "VM.Standard.E4.Flex"

              [32m+[0m[0m create_vnic_details {
                  [32m+[0m[0m assign_ipv6ip             = (known after apply)
                  [32m+[0m[0m assign_private_dns_record = true
                  [32m+[0m[0m assign_public_ip          = false
                  [32m+[0m[0m defined_tags              = (known after apply)
                  [32m+[0m[0m display_name              = (known after apply)
                  [32m+[0m[0m freeform_tags             = (known after apply)
                  [32m+[0m[0m hostname_label            = (known after apply)
                  [32m+[0m[0m private_ip                = (known after apply)
                  [32m+[0m[0m private_ip_id             = (known after apply)
                  [32m+[0m[0m security_attributes       = (known after apply)
                  [32m+[0m[0m skip_source_dest_check    = (known after apply)
                  [32m+[0m[0m subnet_cidr               = (known after apply)
                  [32m+[0m[0m subnet_id                 = "ocid1.subnet.oc1..dryrun00000000000000000000000000000000000000000000000001"
                }

              [32m+[0m[0m shape_config {
                  [32m+[0m[0m baseline_ocpu_utilization = (known after apply)
                  [32m+[0m[0m memory_in_gbs             = 8
                  [32m+[0m[0m nvmes                     = (known after apply)
                  [32m+[0m[0m ocpus                     = 1
                  [32m+[0m[0m resource_management       = (known after apply)
                  [32m+[0m[0m vcpus                     = (known after apply)
                }

              [32m+[0m[0m source_details {
                  [32m+[0m[0m boot_volume_id          = (known after apply)
                  [32m+[0m[0m boot_volume_size_in_gbs = (known after apply)
                  [32m+[0m[0m boot_volume_vpus_per_gb = (known after apply)
                  [32m+[0m[0m image_id                = "ocid1.image.oc1..dryrun00000000000000000000000000000000000000000000000000"
                  [32m+[0m[0m kms_key_id              = (known after apply)
                  [32m+[0m[0m source_type             = "image"
                }
            }
        }
    }

[1m  # module.compute.oci_core_instance_pool.this[0m will be created
[0m  [32m+[0m[0m resource "oci_core_instance_pool" "this" {
      [32m+[0m[0m actual_size                     = (known after apply)
      [32m+[0m[0m compartment_id                  = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
      [32m+[0m[0m defined_tags                    = (known after apply)
      [32m+[0m[0m display_name                    = "gateway-instance-pool"
      [32m+[0m[0m freeform_tags                   = (known after apply)
      [32m+[0m[0m id                              = (known after apply)
      [32m+[0m[0m instance_configuration_id       = (known after apply)
      [32m+[0m[0m instance_display_name_formatter = (known after apply)
      [32m+[0m[0m instance_hostname_formatter     = (known after apply)
      [32m+[0m[0m size                            = 1
      [32m+[0m[0m state                           = (known after apply)
      [32m+[0m[0m time_created                    = (known after apply)

      [32m+[0m[0m placement_configurations {
          [32m+[0m[0m availability_domain = "Uocm:PHX-AD-1"
          [32m+[0m[0m fault_domains       = (known after apply)
          [32m+[0m[0m primary_subnet_id   = "ocid1.subnet.oc1..dryrun00000000000000000000000000000000000000000000000001"
        }
    }

[1m  # module.iam.oci_identity_policy.this[0m will be created
[0m  [32m+[0m[0m resource "oci_identity_policy" "this" {
      [32m+[0m[0m ETag           = (known after apply)
      [32m+[0m[0m compartment_id = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
      [32m+[0m[0m defined_tags   = (known after apply)
      [32m+[0m[0m description    = "IAM policies required for NLB + instance pool + autoscaling."
      [32m+[0m[0m freeform_tags  = (known after apply)
      [32m+[0m[0m id             = (known after apply)
      [32m+[0m[0m inactive_state = (known after apply)
      [32m+[0m[0m lastUpdateETag = (known after apply)
      [32m+[0m[0m name           = "gateway-instance-autoscale-policy"
      [32m+[0m[0m policyHash     = (known after apply)
      [32m+[0m[0m state          = (known after apply)
      [32m+[0m[0m statements     = [
          [32m+[0m[0m "Allow service autoscaling to manage instance-pools in compartment id <compartment_ocid>",
          [32m+[0m[0m "Allow service autoscaling to read metrics in compartment id <compartment_ocid>",
          [32m+[0m[0m "Allow service compute to manage instance-family in compartment id <compartment_ocid>",
          [32m+[0m[0m "Allow service compute to use subnets in compartment id <compartment_ocid>",
          [32m+[0m[0m "Allow service compute to use network-security-groups in compartment id <compartment_ocid>",
          [32m+[0m[0m "Allow service network-load-balancer to use subnets in compartment id <compartment_ocid>",
          [32m+[0m[0m "Allow service network-load-balancer to use network-security-groups in compartment id <compartment_ocid>",
        ]
      [32m+[0m[0m time_created   = (known after apply)
      [32m+[0m[0m version_date   = (known after apply)
    }

[1m  # module.nlb.oci_network_load_balancer_backend_set.this[0m will be created
[0m  [32m+[0m[0m resource "oci_network_load_balancer_backend_set" "this" {
      [32m+[0m[0m are_operationally_active_backends_preferred = (known after apply)
      [32m+[0m[0m backends                                    = (known after apply)
      [32m+[0m[0m id                                          = (known after apply)
      [32m+[0m[0m ip_version                                  = (known after apply)
      [32m+[0m[0m is_fail_open                                = (known after apply)
      [32m+[0m[0m is_instant_failover_enabled                 = (known after apply)
      [32m+[0m[0m is_instant_failover_tcp_reset_enabled       = (known after apply)
      [32m+[0m[0m is_preserve_source                          = (known after apply)
      [32m+[0m[0m name                                        = "backend-set"
      [32m+[0m[0m network_load_balancer_id                    = (known after apply)
      [32m+[0m[0m policy                                      = "FIVE_TUPLE"

      [32m+[0m[0m health_checker {
          [32m+[0m[0m interval_in_millis  = (known after apply)
          [32m+[0m[0m port                = 8080
          [32m+[0m[0m protocol            = "TCP"
          [32m+[0m[0m request_data        = (known after apply)
          [32m+[0m[0m response_body_regex = (known after apply)
          [32m+[0m[0m response_data       = (known after apply)
          [32m+[0m[0m retries             = (known after apply)
          [32m+[0m[0m return_code         = (known after apply)
          [32m+[0m[0m timeout_in_millis   = (known after apply)
          [32m+[0m[0m url_path            = (known after apply)
        }
    }

[1m  # module.nlb.oci_network_load_balancer_listener.this[0m will be created
[0m  [32m+[0m[0m resource "oci_network_load_balancer_listener" "this" {
      [32m+[0m[0m default_backend_set_name = "backend-set"
      [32m+[0m[0m id                       = (known after apply)
      [32m+[0m[0m ip_version               = (known after apply)
      [32m+[0m[0m is_ppv2enabled           = (known after apply)
      [32m+[0m[0m l3ip_idle_timeout        = (known after apply)
      [32m+[0m[0m name                     = "listener"
      [32m+[0m[0m network_load_balancer_id = (known after apply)
      [32m+[0m[0m port                     = 80
      [32m+[0m[0m protocol                 = "TCP"
      [32m+[0m[0m tcp_idle_timeout         = (known after apply)
      [32m+[0m[0m udp_idle_timeout         = (known after apply)
    }

[1m  # module.nlb.oci_network_load_balancer_network_load_balancer.this[0m will be created
[0m  [32m+[0m[0m resource "oci_network_load_balancer_network_load_balancer" "this" {
      [32m+[0m[0m compartment_id                 = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
      [32m+[0m[0m defined_tags                   = (known after apply)
      [32m+[0m[0m display_name                   = "gateway-nlb"
      [32m+[0m[0m freeform_tags                  = (known after apply)
      [32m+[0m[0m id                             = (known after apply)
      [32m+[0m[0m ip_addresses                   = (known after apply)
      [32m+[0m[0m is_preserve_source_destination = (known after apply)
      [32m+[0m[0m is_private                     = true
      [32m+[0m[0m is_symmetric_hash_enabled      = (known after apply)
      [32m+[0m[0m lifecycle_details              = (known after apply)
      [32m+[0m[0m nlb_ip_version                 = (known after apply)
      [32m+[0m[0m security_attributes            = (known after apply)
      [32m+[0m[0m state                          = (known after apply)
      [32m+[0m[0m subnet_id                      = "ocid1.subnet.oc1..dryrun00000000000000000000000000000000000000000000000000"
      [32m+[0m[0m system_tags                    = (known after apply)
      [32m+[0m[0m time_created                   = (known after apply)
      [32m+[0m[0m time_updated                   = (known after apply)
    }

[1mPlan:[0m 7 to add, 0 to change, 0 to destroy.
[0m
Changes to Outputs:
  [32m+[0m[0m autoscaling_configuration_id = (known after apply)
  [32m+[0m[0m iam_policy_id                = (known after apply)
  [32m+[0m[0m instance_pool_id             = (known after apply)
  [32m+[0m[0m nlb_id                       = (known after apply)
[90m
─────────────────────────────────────────────────────────────────────────────[0m

Saved the plan to: plan.out

To perform exactly these actions, run the following command to apply:
    terraform apply "plan.out"

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.autoscaling.oci_autoscaling_auto_scaling_configuration.this will be created
  + resource "oci_autoscaling_auto_scaling_configuration" "this" {
      + compartment_id       = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
      + cool_down_in_seconds = (known after apply)
      + defined_tags         = (known after apply)
      + display_name         = "instance-pool-autoscaling"
      + freeform_tags        = (known after apply)
      + id                   = (known after apply)
      + is_enabled           = true
      + max_resource_count   = (known after apply)
      + min_resource_count   = (known after apply)
      + time_created         = (known after apply)

      + auto_scaling_resources {
          + id   = (known after apply)
          + type = "instancePool"
        }

      + policies {
          + display_name = "cpu-scaling-policy"
          + id           = (known after apply)
          + is_enabled   = true
          + policy_type  = "threshold"
          + time_created = (known after apply)

          + capacity {
              + initial = 1
              + max     = 3
              + min     = 1
            }

          + rules {
              + display_name = "scale-in"
              + id           = (known after apply)

              + action {
                  + type  = "CHANGE_COUNT_BY"
                  + value = -1
                }

              + metric {
                  + metric_source    = "COMPUTE_AGENT"
                  + metric_type      = "CPU_UTILIZATION"
                  + pending_duration = "PT3M"
                }
            }
          + rules {
              + display_name = "scale-out"
              + id           = (known after apply)

              + action {
                  + type  = "CHANGE_COUNT_BY"
                  + value = 1
                }

              + metric {
                  + metric_source    = "COMPUTE_AGENT"
                  + metric_type      = "CPU_UTILIZATION"
                  + pending_duration = "PT3M"
                }
            }
        }
    }

  # module.compute.oci_core_instance_configuration.this will be created
  + resource "oci_core_instance_configuration" "this" {
      + compartment_id  = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
      + deferred_fields = (known after apply)
      + defined_tags    = (known after apply)
      + display_name    = "gateway-instance-config"
      + freeform_tags   = (known after apply)
      + id              = (known after apply)
      + instance_id     = (known after apply)
      + source          = (known after apply)
      + time_created    = (known after apply)

      + instance_details {
          + instance_type = "compute"

          + launch_details {
              + availability_domain                 = (known after apply)
              + capacity_reservation_id             = (known after apply)
              + cluster_placement_group_id          = (known after apply)
              + compartment_id                      = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
              + compute_cluster_id                  = (known after apply)
              + dedicated_vm_host_id                = (known after apply)
              + defined_tags                        = (known after apply)
              + display_name                        = (known after apply)
              + extended_metadata                   = (known after apply)
              + fault_domain                        = (known after apply)
              + freeform_tags                       = (known after apply)
              + ipxe_script                         = (known after apply)
              + is_ai_enterprise_enabled            = (known after apply)
              + is_pv_encryption_in_transit_enabled = (known after apply)
              + launch_mode                         = (known after apply)
              + metadata                            = {
                  + "ssh_authorized_keys" = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD"
                  + "user_data"           = ""
                }
              + preferred_maintenance_action        = (known after apply)
              + security_attributes                 = (known after apply)
              + shape                               = "VM.Standard.E4.Flex"

              + create_vnic_details {
                  + assign_ipv6ip             = (known after apply)
                  + assign_private_dns_record = true
                  + assign_public_ip          = false
                  + defined_tags              = (known after apply)
                  + display_name              = (known after apply)
                  + freeform_tags             = (known after apply)
                  + hostname_label            = (known after apply)
                  + private_ip                = (known after apply)
                  + private_ip_id             = (known after apply)
                  + security_attributes       = (known after apply)
                  + skip_source_dest_check    = (known after apply)
                  + subnet_cidr               = (known after apply)
                  + subnet_id                 = "ocid1.subnet.oc1..dryrun00000000000000000000000000000000000000000000000001"
                }

              + shape_config {
                  + baseline_ocpu_utilization = (known after apply)
                  + memory_in_gbs             = 8
                  + nvmes                     = (known after apply)
                  + ocpus                     = 1
                  + resource_management       = (known after apply)
                  + vcpus                     = (known after apply)
                }

              + source_details {
                  + boot_volume_id          = (known after apply)
                  + boot_volume_size_in_gbs = (known after apply)
                  + boot_volume_vpus_per_gb = (known after apply)
                  + image_id                = "ocid1.image.oc1..dryrun00000000000000000000000000000000000000000000000000"
                  + kms_key_id              = (known after apply)
                  + source_type             = "image"
                }
            }
        }
    }

  # module.compute.oci_core_instance_pool.this will be created
  + resource "oci_core_instance_pool" "this" {
      + actual_size                     = (known after apply)
      + compartment_id                  = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
      + defined_tags                    = (known after apply)
      + display_name                    = "gateway-instance-pool"
      + freeform_tags                   = (known after apply)
      + id                              = (known after apply)
      + instance_configuration_id       = (known after apply)
      + instance_display_name_formatter = (known after apply)
      + instance_hostname_formatter     = (known after apply)
      + size                            = 1
      + state                           = (known after apply)
      + time_created                    = (known after apply)

      + placement_configurations {
          + availability_domain = "Uocm:PHX-AD-1"
          + fault_domains       = (known after apply)
          + primary_subnet_id   = "ocid1.subnet.oc1..dryrun00000000000000000000000000000000000000000000000001"
        }
    }

  # module.iam.oci_identity_policy.this will be created
  + resource "oci_identity_policy" "this" {
      + ETag           = (known after apply)
      + compartment_id = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
      + defined_tags   = (known after apply)
      + description    = "IAM policies required for NLB + instance pool + autoscaling."
      + freeform_tags  = (known after apply)
      + id             = (known after apply)
      + inactive_state = (known after apply)
      + lastUpdateETag = (known after apply)
      + name           = "gateway-instance-autoscale-policy"
      + policyHash     = (known after apply)
      + state          = (known after apply)
      + statements     = [
          + "Allow service autoscaling to manage instance-pools in compartment id <compartment_ocid>",
          + "Allow service autoscaling to read metrics in compartment id <compartment_ocid>",
          + "Allow service compute to manage instance-family in compartment id <compartment_ocid>",
          + "Allow service compute to use subnets in compartment id <compartment_ocid>",
          + "Allow service compute to use network-security-groups in compartment id <compartment_ocid>",
          + "Allow service network-load-balancer to use subnets in compartment id <compartment_ocid>",
          + "Allow service network-load-balancer to use network-security-groups in compartment id <compartment_ocid>",
        ]
      + time_created   = (known after apply)
      + version_date   = (known after apply)
    }

  # module.nlb.oci_network_load_balancer_backend_set.this will be created
  + resource "oci_network_load_balancer_backend_set" "this" {
      + are_operationally_active_backends_preferred = (known after apply)
      + backends                                    = (known after apply)
      + id                                          = (known after apply)
      + ip_version                                  = (known after apply)
      + is_fail_open                                = (known after apply)
      + is_instant_failover_enabled                 = (known after apply)
      + is_instant_failover_tcp_reset_enabled       = (known after apply)
      + is_preserve_source                          = (known after apply)
      + name                                        = "backend-set"
      + network_load_balancer_id                    = (known after apply)
      + policy                                      = "FIVE_TUPLE"

      + health_checker {
          + interval_in_millis  = (known after apply)
          + port                = 8080
          + protocol            = "TCP"
          + request_data        = (known after apply)
          + response_body_regex = (known after apply)
          + response_data       = (known after apply)
          + retries             = (known after apply)
          + return_code         = (known after apply)
          + timeout_in_millis   = (known after apply)
          + url_path            = (known after apply)
        }
    }

  # module.nlb.oci_network_load_balancer_listener.this will be created
  + resource "oci_network_load_balancer_listener" "this" {
      + default_backend_set_name = "backend-set"
      + id                       = (known after apply)
      + ip_version               = (known after apply)
      + is_ppv2enabled           = (known after apply)
      + l3ip_idle_timeout        = (known after apply)
      + name                     = "listener"
      + network_load_balancer_id = (known after apply)
      + port                     = 80
      + protocol                 = "TCP"
      + tcp_idle_timeout         = (known after apply)
      + udp_idle_timeout         = (known after apply)
    }

  # module.nlb.oci_network_load_balancer_network_load_balancer.this will be created
  + resource "oci_network_load_balancer_network_load_balancer" "this" {
      + compartment_id                 = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
      + defined_tags                   = (known after apply)
      + display_name                   = "gateway-nlb"
      + freeform_tags                  = (known after apply)
      + id                             = (known after apply)
      + ip_addresses                   = (known after apply)
      + is_preserve_source_destination = (known after apply)
      + is_private                     = true
      + is_symmetric_hash_enabled      = (known after apply)
      + lifecycle_details              = (known after apply)
      + nlb_ip_version                 = (known after apply)
      + security_attributes            = (known after apply)
      + state                          = (known after apply)
      + subnet_id                      = "ocid1.subnet.oc1..dryrun00000000000000000000000000000000000000000000000000"
      + system_tags                    = (known after apply)
      + time_created                   = (known after apply)
      + time_updated                   = (known after apply)
    }

Plan: 7 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + autoscaling_configuration_id = (known after apply)
  + iam_policy_id                = (known after apply)
  + instance_pool_id             = (known after apply)
  + nlb_id                       = (known after apply)
```