### PR TITLE
feat: add OCI Terraform template — object-events-function-logging

### DIFF
--- a/object-events-function-logging/.terraform.lock.hcl
+++ b/object-events-function-logging/.terraform.lock.hcl
@@ -1,0 +1,47 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/oci" {
+  version = "8.7.0"
+  hashes = [
+    "h1:Jcnomog7lTrOEXmDWZaqEZFMO2R5FAJJlcNq2js7PMQ=",
+    "zh:06edf1a61c0cb335dc6691c25e9e9d9dad794ed78901e2b9c1ea960eeb62404b",
+    "zh:250c86a2a8ed41a2c0dd592f99ccd8ea2e6e4381da9dbd435fd6cab8742faea9",
+    "zh:30172fc1e69c9247f905198900caa20602327a2a91b8e441b5db782235f5a2b6",
+    "zh:475bf4b38637a6a6267dfd95450fb2d0f31000c66ee4fe0def6aba89fb8911a1",
+    "zh:4bee6badede6a846ae2746a9dc1e0ad864d2f2b4fc2acac3a5f7bbbeb5a0fceb",
+    "zh:51cf23af41250c35f7ad899b5b2cdc7e33d197d8d626fd09d23114b4f683eb57",
+    "zh:606801f070b3e4c27caabfc82bed7142b410b033b02e12e3d561a2dd8249a976",
+    "zh:641b7c840df8ed2215f94db309e358bf5c2a387a55e90f680a00f13197ac97a5",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9d09e0bd02d6f67df4a1b58dd0d3cc185451d60abdbcc4b8d3d0f87bbd4f47ae",
+    "zh:a34a5c400fc1324747122df27a10607918f1034d96f9812c5325e1b651bfc213",
+    "zh:c063fdd82333594072a67f522ca2caf1fb2d55a64c7c7ee0b718c59a321e31e6",
+    "zh:c55053d12729514bd728425cd79829dea631db52a24cc6aa60008be9099a28ba",
+    "zh:ca593d91b4ad37092c5ba0ae5fbe28033b3fc3440769d27cde28fe906ca5968f",
+    "zh:e58e1ab032591e18dd487f1dcc8f9581ab69f0709377276689f0fc6dd14fdcb9",
+  ]
+}
+
+provider "registry.terraform.io/oracle/oci" {
+  version     = "8.7.0"
+  constraints = ">= 5.0.0"
+  hashes = [
+    "h1:Jcnomog7lTrOEXmDWZaqEZFMO2R5FAJJlcNq2js7PMQ=",
+    "zh:06edf1a61c0cb335dc6691c25e9e9d9dad794ed78901e2b9c1ea960eeb62404b",
+    "zh:250c86a2a8ed41a2c0dd592f99ccd8ea2e6e4381da9dbd435fd6cab8742faea9",
+    "zh:30172fc1e69c9247f905198900caa20602327a2a91b8e441b5db782235f5a2b6",
+    "zh:475bf4b38637a6a6267dfd95450fb2d0f31000c66ee4fe0def6aba89fb8911a1",
+    "zh:4bee6badede6a846ae2746a9dc1e0ad864d2f2b4fc2acac3a5f7bbbeb5a0fceb",
+    "zh:51cf23af41250c35f7ad899b5b2cdc7e33d197d8d626fd09d23114b4f683eb57",
+    "zh:606801f070b3e4c27caabfc82bed7142b410b033b02e12e3d561a2dd8249a976",
+    "zh:641b7c840df8ed2215f94db309e358bf5c2a387a55e90f680a00f13197ac97a5",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9d09e0bd02d6f67df4a1b58dd0d3cc185451d60abdbcc4b8d3d0f87bbd4f47ae",
+    "zh:a34a5c400fc1324747122df27a10607918f1034d96f9812c5325e1b651bfc213",
+    "zh:c063fdd82333594072a67f522ca2caf1fb2d55a64c7c7ee0b718c59a321e31e6",
+    "zh:c55053d12729514bd728425cd79829dea631db52a24cc6aa60008be9099a28ba",
+    "zh:ca593d91b4ad37092c5ba0ae5fbe28033b3fc3440769d27cde28fe906ca5968f",
+    "zh:e58e1ab032591e18dd487f1dcc8f9581ab69f0709377276689f0fc6dd14fdcb9",
+  ]
+}

--- a/object-events-function-logging/README.md
+++ b/object-events-function-logging/README.md
@@ -1,0 +1,67 @@
+# object-events-function-logging
+
+This template creates an Object Storage bucket, an Events rule to invoke a Function on object creation, and a Service Connector to route function logs into OCI Logging.
+
+Module structure:
+- networking: pass-through for existing network IDs
+- objectstorage: bucket with object events enabled
+- functions: functions application + function
+- events: events rule invoking the function
+- logging: log group + log
+- service-connector: routes logs to Logging
+
+Architecture tree:
+object-events-function-logging/
+- main.tf
+- variables.tf
+- outputs.tf
+- versions.tf
+- README.md
+- modules/
+  - networking/
+    - main.tf
+    - variables.tf
+    - outputs.tf
+  - objectstorage/
+    - main.tf
+    - variables.tf
+    - outputs.tf
+  - functions/
+    - main.tf
+    - variables.tf
+    - outputs.tf
+  - events/
+    - main.tf
+    - variables.tf
+    - outputs.tf
+  - logging/
+    - main.tf
+    - variables.tf
+    - outputs.tf
+  - service-connector/
+    - main.tf
+    - variables.tf
+    - outputs.tf
+
+Prerequisites:
+- OCI tenancy with permissions for Object Storage, Events, Functions, Logging, and Service Connector Hub
+- Existing VCN and subnets for Functions
+
+Usage:
+module "object_events_function_logging" {
+  source = "./object-events-function-logging"
+
+  compartment_id          = "ocid1.compartment.oc1..example"
+  vcn_id                  = "ocid1.vcn.oc1..example"
+  function_subnet_ids     = ["ocid1.subnet.oc1..example"]
+  objectstorage_namespace = "my-namespace"
+  bucket_name             = "my-bucket"
+  function_image          = "phx.ocir.io/tenancy/image:tag"
+}
+
+Outputs:
+- bucket_id
+- function_id
+- events_rule_id
+- log_group_id
+- service_connector_id

--- a/object-events-function-logging/main.tf
+++ b/object-events-function-logging/main.tf
@@ -1,0 +1,76 @@
+provider "oci" {}
+
+locals {
+  event_condition = var.event_condition != "" ? var.event_condition : jsonencode({
+    eventType = ["com.oraclecloud.objectstorage.createobject"]
+    data = {
+      compartmentId = [var.compartment_id]
+      resourceName  = [var.bucket_name]
+    }
+  })
+}
+
+module "networking" {
+  source = "./modules/networking"
+
+  compartment_id      = var.compartment_id
+  vcn_id              = var.vcn_id
+  function_subnet_ids = var.function_subnet_ids
+  function_nsg_ids    = var.function_nsg_ids
+}
+
+module "objectstorage" {
+  source = "./modules/objectstorage"
+
+  compartment_id        = var.compartment_id
+  namespace             = var.objectstorage_namespace
+  bucket_name           = var.bucket_name
+  storage_tier          = var.bucket_storage_tier
+  object_events_enabled = var.object_events_enabled
+}
+
+module "functions" {
+  source = "./modules/functions"
+
+  compartment_id           = var.compartment_id
+  application_name         = var.application_name
+  application_subnet_ids   = module.networking.function_subnet_ids
+  application_nsg_ids      = module.networking.function_nsg_ids
+  application_shape        = var.application_shape
+
+  function_name              = var.function_name
+  function_image             = var.function_image
+  function_memory_in_mbs     = var.function_memory_in_mbs
+  function_timeout_in_seconds = var.function_timeout_in_seconds
+}
+
+module "events" {
+  source = "./modules/events"
+
+  compartment_id   = var.compartment_id
+  rule_name        = var.event_rule_name
+  rule_description = var.event_rule_description
+  condition        = local.event_condition
+  function_id      = module.functions.function_id
+}
+
+module "logging" {
+  source = "./modules/logging"
+
+  compartment_id       = var.compartment_id
+  log_group_name       = var.log_group_name
+  log_name             = var.log_name
+  function_resource_id = module.functions.function_id
+}
+
+module "service_connector" {
+  source = "./modules/service-connector"
+
+  compartment_id       = var.compartment_id
+  connector_name       = var.service_connector_name
+  source_log_group_id  = module.logging.log_group_id
+  source_log_id        = module.logging.log_id
+
+  target_kind          = var.service_connector_target_kind
+  target_log_group_id  = module.logging.log_group_id
+}

--- a/object-events-function-logging/modules/events/main.tf
+++ b/object-events-function-logging/modules/events/main.tf
@@ -1,0 +1,15 @@
+resource "oci_events_rule" "this" {
+  compartment_id = var.compartment_id
+  display_name   = var.rule_name
+  description    = var.rule_description
+  condition      = var.condition
+  is_enabled     = true
+
+  actions {
+    actions {
+      action_type = "FAAS"
+      function_id = var.function_id
+      is_enabled  = true
+    }
+  }
+}

--- a/object-events-function-logging/modules/events/outputs.tf
+++ b/object-events-function-logging/modules/events/outputs.tf
@@ -1,0 +1,4 @@
+output "rule_id" {
+  description = "Events rule OCID."
+  value       = oci_events_rule.this.id
+}

--- a/object-events-function-logging/modules/events/variables.tf
+++ b/object-events-function-logging/modules/events/variables.tf
@@ -1,0 +1,24 @@
+variable "compartment_id" {
+  type        = string
+  description = "Compartment OCID."
+}
+
+variable "rule_name" {
+  type        = string
+  description = "Rule name."
+}
+
+variable "rule_description" {
+  type        = string
+  description = "Rule description."
+}
+
+variable "condition" {
+  type        = string
+  description = "Event condition JSON string."
+}
+
+variable "function_id" {
+  type        = string
+  description = "Function OCID to invoke."
+}

--- a/object-events-function-logging/modules/functions/main.tf
+++ b/object-events-function-logging/modules/functions/main.tf
@@ -1,0 +1,15 @@
+resource "oci_functions_application" "this" {
+  compartment_id             = var.compartment_id
+  display_name               = var.application_name
+  subnet_ids                 = var.application_subnet_ids
+  network_security_group_ids = var.application_nsg_ids
+  shape                      = var.application_shape
+}
+
+resource "oci_functions_function" "this" {
+  application_id         = oci_functions_application.this.id
+  display_name           = var.function_name
+  image                  = var.function_image
+  memory_in_mbs          = var.function_memory_in_mbs
+  timeout_in_seconds     = var.function_timeout_in_seconds
+}

--- a/object-events-function-logging/modules/functions/outputs.tf
+++ b/object-events-function-logging/modules/functions/outputs.tf
@@ -1,0 +1,4 @@
+output "function_id" {
+  description = "Function OCID."
+  value       = oci_functions_function.this.id
+}

--- a/object-events-function-logging/modules/functions/variables.tf
+++ b/object-events-function-logging/modules/functions/variables.tf
@@ -1,0 +1,48 @@
+variable "compartment_id" {
+  type        = string
+  description = "Compartment OCID."
+}
+
+variable "application_name" {
+  type        = string
+  description = "Functions application name."
+}
+
+variable "application_subnet_ids" {
+  type        = list(string)
+  description = "Subnets for the Functions application."
+}
+
+variable "application_nsg_ids" {
+  type        = list(string)
+  description = "NSG IDs for the Functions application."
+  default     = []
+}
+
+variable "application_shape" {
+  type        = string
+  description = "Functions application shape."
+  default     = "GENERIC_X86"
+}
+
+variable "function_name" {
+  type        = string
+  description = "Function name."
+}
+
+variable "function_image" {
+  type        = string
+  description = "Function image (OCIR)."
+}
+
+variable "function_memory_in_mbs" {
+  type        = number
+  description = "Function memory in MB."
+  default     = 256
+}
+
+variable "function_timeout_in_seconds" {
+  type        = number
+  description = "Function timeout in seconds."
+  default     = 30
+}

--- a/object-events-function-logging/modules/logging/main.tf
+++ b/object-events-function-logging/modules/logging/main.tf
@@ -1,0 +1,20 @@
+resource "oci_logging_log_group" "this" {
+  compartment_id = var.compartment_id
+  display_name   = var.log_group_name
+}
+
+resource "oci_logging_log" "this" {
+  log_group_id   = oci_logging_log_group.this.id
+  display_name   = var.log_name
+  log_type       = "CUSTOM"
+
+  configuration {
+    compartment_id = var.compartment_id
+    source {
+      source_type = "OCISERVICE"
+      service     = "functions"
+      resource    = var.function_resource_id
+      category    = "invoke"
+    }
+  }
+}

--- a/object-events-function-logging/modules/logging/outputs.tf
+++ b/object-events-function-logging/modules/logging/outputs.tf
@@ -1,0 +1,9 @@
+output "log_group_id" {
+  description = "Log group OCID."
+  value       = oci_logging_log_group.this.id
+}
+
+output "log_id" {
+  description = "Log OCID."
+  value       = oci_logging_log.this.id
+}

--- a/object-events-function-logging/modules/logging/variables.tf
+++ b/object-events-function-logging/modules/logging/variables.tf
@@ -1,0 +1,19 @@
+variable "compartment_id" {
+  type        = string
+  description = "Compartment OCID."
+}
+
+variable "log_group_name" {
+  type        = string
+  description = "Log group name."
+}
+
+variable "log_name" {
+  type        = string
+  description = "Log name."
+}
+
+variable "function_resource_id" {
+  type        = string
+  description = "Function OCID for log source."
+}

--- a/object-events-function-logging/modules/networking/main.tf
+++ b/object-events-function-logging/modules/networking/main.tf
@@ -1,0 +1,1 @@
+# Pass-through module for existing network resources (no API lookups).

--- a/object-events-function-logging/modules/networking/outputs.tf
+++ b/object-events-function-logging/modules/networking/outputs.tf
@@ -1,0 +1,14 @@
+output "vcn_id" {
+  description = "VCN OCID."
+  value       = var.vcn_id
+}
+
+output "function_subnet_ids" {
+  description = "Function subnet IDs."
+  value       = var.function_subnet_ids
+}
+
+output "function_nsg_ids" {
+  description = "Function NSG IDs."
+  value       = var.function_nsg_ids
+}

--- a/object-events-function-logging/modules/networking/variables.tf
+++ b/object-events-function-logging/modules/networking/variables.tf
@@ -1,0 +1,20 @@
+variable "compartment_id" {
+  type        = string
+  description = "Compartment OCID."
+}
+
+variable "vcn_id" {
+  type        = string
+  description = "VCN OCID."
+}
+
+variable "function_subnet_ids" {
+  type        = list(string)
+  description = "Subnet IDs for Functions."
+}
+
+variable "function_nsg_ids" {
+  type        = list(string)
+  description = "NSG IDs for Functions."
+  default     = []
+}

--- a/object-events-function-logging/modules/objectstorage/main.tf
+++ b/object-events-function-logging/modules/objectstorage/main.tf
@@ -1,0 +1,7 @@
+resource "oci_objectstorage_bucket" "this" {
+  compartment_id        = var.compartment_id
+  namespace             = var.namespace
+  name                  = var.bucket_name
+  storage_tier          = var.storage_tier
+  object_events_enabled = var.object_events_enabled
+}

--- a/object-events-function-logging/modules/objectstorage/outputs.tf
+++ b/object-events-function-logging/modules/objectstorage/outputs.tf
@@ -1,0 +1,4 @@
+output "bucket_id" {
+  description = "Bucket OCID."
+  value       = oci_objectstorage_bucket.this.id
+}

--- a/object-events-function-logging/modules/objectstorage/variables.tf
+++ b/object-events-function-logging/modules/objectstorage/variables.tf
@@ -1,0 +1,26 @@
+variable "compartment_id" {
+  type        = string
+  description = "Compartment OCID."
+}
+
+variable "namespace" {
+  type        = string
+  description = "Object Storage namespace."
+}
+
+variable "bucket_name" {
+  type        = string
+  description = "Bucket name."
+}
+
+variable "storage_tier" {
+  type        = string
+  description = "Storage tier."
+  default     = "Standard"
+}
+
+variable "object_events_enabled" {
+  type        = bool
+  description = "Enable object events."
+  default     = true
+}

--- a/object-events-function-logging/modules/service-connector/main.tf
+++ b/object-events-function-logging/modules/service-connector/main.tf
@@ -1,0 +1,19 @@
+resource "oci_sch_service_connector" "this" {
+  compartment_id = var.compartment_id
+  display_name   = var.connector_name
+
+  source {
+    kind = "logging"
+    log_sources {
+      compartment_id = var.compartment_id
+      log_group_id   = var.source_log_group_id
+      log_id         = var.source_log_id
+    }
+  }
+
+  target {
+    kind           = var.target_kind
+    compartment_id = var.compartment_id
+    log_group_id   = var.target_log_group_id
+  }
+}

--- a/object-events-function-logging/modules/service-connector/outputs.tf
+++ b/object-events-function-logging/modules/service-connector/outputs.tf
@@ -1,0 +1,4 @@
+output "connector_id" {
+  description = "Service Connector OCID."
+  value       = oci_sch_service_connector.this.id
+}

--- a/object-events-function-logging/modules/service-connector/variables.tf
+++ b/object-events-function-logging/modules/service-connector/variables.tf
@@ -1,0 +1,29 @@
+variable "compartment_id" {
+  type        = string
+  description = "Compartment OCID."
+}
+
+variable "connector_name" {
+  type        = string
+  description = "Service Connector name."
+}
+
+variable "source_log_group_id" {
+  type        = string
+  description = "Source log group OCID."
+}
+
+variable "source_log_id" {
+  type        = string
+  description = "Source log OCID."
+}
+
+variable "target_kind" {
+  type        = string
+  description = "Target kind for service connector."
+}
+
+variable "target_log_group_id" {
+  type        = string
+  description = "Target log group OCID."
+}

--- a/object-events-function-logging/outputs.tf
+++ b/object-events-function-logging/outputs.tf
@@ -1,0 +1,24 @@
+output "bucket_id" {
+  description = "Bucket OCID."
+  value       = module.objectstorage.bucket_id
+}
+
+output "function_id" {
+  description = "Function OCID."
+  value       = module.functions.function_id
+}
+
+output "events_rule_id" {
+  description = "Events rule OCID."
+  value       = module.events.rule_id
+}
+
+output "log_group_id" {
+  description = "Log Group OCID."
+  value       = module.logging.log_group_id
+}
+
+output "service_connector_id" {
+  description = "Service Connector OCID."
+  value       = module.service_connector.connector_id
+}

--- a/object-events-function-logging/plan.txt
+++ b/object-events-function-logging/plan.txt
@@ -1,0 +1,443 @@
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  [32m+[0m create[0m
+
+Terraform will perform the following actions:
+
+[1m  # module.events.oci_events_rule.this[0m will be created
+[0m  [32m+[0m[0m resource "oci_events_rule" "this" {
+      [32m+[0m[0m compartment_id    = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+      [32m+[0m[0m condition         = jsonencode(
+            {
+              [32m+[0m[0m data      = {
+                  [32m+[0m[0m compartmentId = [
+                      [32m+[0m[0m "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000",
+                    ]
+                  [32m+[0m[0m resourceName  = [
+                      [32m+[0m[0m "my-bucket",
+                    ]
+                }
+              [32m+[0m[0m eventType = [
+                  [32m+[0m[0m "com.oraclecloud.objectstorage.createobject",
+                ]
+            }
+        )
+      [32m+[0m[0m defined_tags      = (known after apply)
+      [32m+[0m[0m description       = "Trigger Functions when objects are created."
+      [32m+[0m[0m display_name      = "object-create-events"
+      [32m+[0m[0m freeform_tags     = (known after apply)
+      [32m+[0m[0m id                = (known after apply)
+      [32m+[0m[0m is_enabled        = true
+      [32m+[0m[0m lifecycle_message = (known after apply)
+      [32m+[0m[0m state             = (known after apply)
+      [32m+[0m[0m time_created      = (known after apply)
+
+      [32m+[0m[0m actions {
+          [32m+[0m[0m actions {
+              [32m+[0m[0m action_type       = "FAAS"
+              [32m+[0m[0m description       = (known after apply)
+              [32m+[0m[0m function_id       = (known after apply)
+              [32m+[0m[0m id                = (known after apply)
+              [32m+[0m[0m is_enabled        = true
+              [32m+[0m[0m lifecycle_message = (known after apply)
+              [32m+[0m[0m state             = (known after apply)
+              [32m+[0m[0m stream_id         = (known after apply)
+              [32m+[0m[0m topic_id          = (known after apply)
+            }
+        }
+    }
+
+[1m  # module.functions.oci_functions_application.this[0m will be created
+[0m  [32m+[0m[0m resource "oci_functions_application" "this" {
+      [32m+[0m[0m compartment_id             = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+      [32m+[0m[0m config                     = (known after apply)
+      [32m+[0m[0m defined_tags               = (known after apply)
+      [32m+[0m[0m display_name               = "object-events-app"
+      [32m+[0m[0m freeform_tags              = (known after apply)
+      [32m+[0m[0m id                         = (known after apply)
+      [32m+[0m[0m network_security_group_ids = (known after apply)
+      [32m+[0m[0m security_attributes        = (known after apply)
+      [32m+[0m[0m shape                      = "GENERIC_X86"
+      [32m+[0m[0m state                      = (known after apply)
+      [32m+[0m[0m subnet_ids                 = [
+          [32m+[0m[0m "ocid1.subnet.oc1..dryrun00000000000000000000000000000000000000000000000000",
+        ]
+      [32m+[0m[0m syslog_url                 = (known after apply)
+      [32m+[0m[0m time_created               = (known after apply)
+      [32m+[0m[0m time_updated               = (known after apply)
+    }
+
+[1m  # module.functions.oci_functions_function.this[0m will be created
+[0m  [32m+[0m[0m resource "oci_functions_function" "this" {
+      [32m+[0m[0m application_id                   = (known after apply)
+      [32m+[0m[0m compartment_id                   = (known after apply)
+      [32m+[0m[0m config                           = (known after apply)
+      [32m+[0m[0m defined_tags                     = (known after apply)
+      [32m+[0m[0m detached_mode_timeout_in_seconds = (known after apply)
+      [32m+[0m[0m display_name                     = "image-processor"
+      [32m+[0m[0m freeform_tags                    = (known after apply)
+      [32m+[0m[0m id                               = (known after apply)
+      [32m+[0m[0m image                            = "phx.ocir.io/tenancy/image:tag"
+      [32m+[0m[0m image_digest                     = (known after apply)
+      [32m+[0m[0m invoke_endpoint                  = (known after apply)
+      [32m+[0m[0m memory_in_mbs                    = "256"
+      [32m+[0m[0m shape                            = (known after apply)
+      [32m+[0m[0m state                            = (known after apply)
+      [32m+[0m[0m time_created                     = (known after apply)
+      [32m+[0m[0m time_updated                     = (known after apply)
+      [32m+[0m[0m timeout_in_seconds               = 30
+    }
+
+[1m  # module.logging.oci_logging_log.this[0m will be created
+[0m  [32m+[0m[0m resource "oci_logging_log" "this" {
+      [32m+[0m[0m compartment_id     = (known after apply)
+      [32m+[0m[0m defined_tags       = (known after apply)
+      [32m+[0m[0m display_name       = "function-log"
+      [32m+[0m[0m freeform_tags      = (known after apply)
+      [32m+[0m[0m id                 = (known after apply)
+      [32m+[0m[0m is_enabled         = (known after apply)
+      [32m+[0m[0m log_group_id       = (known after apply)
+      [32m+[0m[0m log_type           = "CUSTOM"
+      [32m+[0m[0m retention_duration = (known after apply)
+      [32m+[0m[0m state              = (known after apply)
+      [32m+[0m[0m tenancy_id         = (known after apply)
+      [32m+[0m[0m time_created       = (known after apply)
+      [32m+[0m[0m time_last_modified = (known after apply)
+
+      [32m+[0m[0m configuration {
+          [32m+[0m[0m compartment_id = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+
+          [32m+[0m[0m source {
+              [32m+[0m[0m category    = "invoke"
+              [32m+[0m[0m parameters  = (known after apply)
+              [32m+[0m[0m resource    = (known after apply)
+              [32m+[0m[0m service     = "functions"
+              [32m+[0m[0m source_type = "OCISERVICE"
+            }
+        }
+    }
+
+[1m  # module.logging.oci_logging_log_group.this[0m will be created
+[0m  [32m+[0m[0m resource "oci_logging_log_group" "this" {
+      [32m+[0m[0m compartment_id     = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+      [32m+[0m[0m defined_tags       = (known after apply)
+      [32m+[0m[0m description        = (known after apply)
+      [32m+[0m[0m display_name       = "function-logs"
+      [32m+[0m[0m freeform_tags      = (known after apply)
+      [32m+[0m[0m id                 = (known after apply)
+      [32m+[0m[0m state              = (known after apply)
+      [32m+[0m[0m time_created       = (known after apply)
+      [32m+[0m[0m time_last_modified = (known after apply)
+    }
+
+[1m  # module.objectstorage.oci_objectstorage_bucket.this[0m will be created
+[0m  [32m+[0m[0m resource "oci_objectstorage_bucket" "this" {
+      [32m+[0m[0m access_type                  = "NoPublicAccess"
+      [32m+[0m[0m approximate_count            = (known after apply)
+      [32m+[0m[0m approximate_size             = (known after apply)
+      [32m+[0m[0m auto_tiering                 = (known after apply)
+      [32m+[0m[0m bucket_id                    = (known after apply)
+      [32m+[0m[0m compartment_id               = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+      [32m+[0m[0m created_by                   = (known after apply)
+      [32m+[0m[0m defined_tags                 = (known after apply)
+      [32m+[0m[0m etag                         = (known after apply)
+      [32m+[0m[0m freeform_tags                = (known after apply)
+      [32m+[0m[0m id                           = (known after apply)
+      [32m+[0m[0m is_read_only                 = (known after apply)
+      [32m+[0m[0m kms_key_id                   = (known after apply)
+      [32m+[0m[0m name                         = "my-bucket"
+      [32m+[0m[0m namespace                    = "my-namespace"
+      [32m+[0m[0m object_events_enabled        = true
+      [32m+[0m[0m object_lifecycle_policy_etag = (known after apply)
+      [32m+[0m[0m replication_enabled          = (known after apply)
+      [32m+[0m[0m storage_tier                 = "Standard"
+      [32m+[0m[0m time_created                 = (known after apply)
+      [32m+[0m[0m versioning                   = (known after apply)
+    }
+
+[1m  # module.service_connector.oci_sch_service_connector.this[0m will be created
+[0m  [32m+[0m[0m resource "oci_sch_service_connector" "this" {
+      [32m+[0m[0m compartment_id    = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+      [32m+[0m[0m defined_tags      = (known after apply)
+      [32m+[0m[0m description       = (known after apply)
+      [32m+[0m[0m display_name      = "function-log-connector"
+      [32m+[0m[0m freeform_tags     = (known after apply)
+      [32m+[0m[0m id                = (known after apply)
+      [32m+[0m[0m lifecycle_details = (known after apply)
+      [32m+[0m[0m lifecyle_details  = (known after apply)
+      [32m+[0m[0m state             = (known after apply)
+      [32m+[0m[0m system_tags       = (known after apply)
+      [32m+[0m[0m time_created      = (known after apply)
+      [32m+[0m[0m time_updated      = (known after apply)
+
+      [32m+[0m[0m source {
+          [32m+[0m[0m config_map                = (known after apply)
+          [32m+[0m[0m kind                      = "logging"
+          [32m+[0m[0m plugin_name               = (known after apply)
+          [32m+[0m[0m private_endpoint_metadata = (known after apply)
+          [32m+[0m[0m stream_id                 = (known after apply)
+
+          [32m+[0m[0m log_sources {
+              [32m+[0m[0m compartment_id = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+              [32m+[0m[0m log_group_id   = (known after apply)
+              [32m+[0m[0m log_id         = (known after apply)
+            }
+        }
+
+      [32m+[0m[0m target {
+          [32m+[0m[0m batch_rollover_size_in_mbs = (known after apply)
+          [32m+[0m[0m batch_rollover_time_in_ms  = (known after apply)
+          [32m+[0m[0m batch_size_in_kbs          = (known after apply)
+          [32m+[0m[0m batch_size_in_num          = (known after apply)
+          [32m+[0m[0m batch_time_in_sec          = (known after apply)
+          [32m+[0m[0m bucket                     = (known after apply)
+          [32m+[0m[0m compartment_id             = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+          [32m+[0m[0m enable_formatted_messaging = (known after apply)
+          [32m+[0m[0m function_id                = (known after apply)
+          [32m+[0m[0m kind                       = "logging"
+          [32m+[0m[0m log_group_id               = (known after apply)
+          [32m+[0m[0m log_source_identifier      = (known after apply)
+          [32m+[0m[0m metric                     = (known after apply)
+          [32m+[0m[0m metric_namespace           = (known after apply)
+          [32m+[0m[0m namespace                  = (known after apply)
+          [32m+[0m[0m object_name_prefix         = (known after apply)
+          [32m+[0m[0m private_endpoint_metadata  = (known after apply)
+          [32m+[0m[0m stream_id                  = (known after apply)
+          [32m+[0m[0m topic_id                   = (known after apply)
+        }
+    }
+
+[1mPlan:[0m 7 to add, 0 to change, 0 to destroy.
+[0m
+Changes to Outputs:
+  [32m+[0m[0m bucket_id            = (known after apply)
+  [32m+[0m[0m events_rule_id       = (known after apply)
+  [32m+[0m[0m function_id          = (known after apply)
+  [32m+[0m[0m log_group_id         = (known after apply)
+  [32m+[0m[0m service_connector_id = (known after apply)
+[90m
+─────────────────────────────────────────────────────────────────────────────[0m
+
+Saved the plan to: plan.out
+
+To perform exactly these actions, run the following command to apply:
+    terraform apply "plan.out"
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # module.events.oci_events_rule.this will be created
+  + resource "oci_events_rule" "this" {
+      + compartment_id    = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+      + condition         = jsonencode(
+            {
+              + data      = {
+                  + compartmentId = [
+                      + "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000",
+                    ]
+                  + resourceName  = [
+                      + "my-bucket",
+                    ]
+                }
+              + eventType = [
+                  + "com.oraclecloud.objectstorage.createobject",
+                ]
+            }
+        )
+      + defined_tags      = (known after apply)
+      + description       = "Trigger Functions when objects are created."
+      + display_name      = "object-create-events"
+      + freeform_tags     = (known after apply)
+      + id                = (known after apply)
+      + is_enabled        = true
+      + lifecycle_message = (known after apply)
+      + state             = (known after apply)
+      + time_created      = (known after apply)
+
+      + actions {
+          + actions {
+              + action_type       = "FAAS"
+              + description       = (known after apply)
+              + function_id       = (known after apply)
+              + id                = (known after apply)
+              + is_enabled        = true
+              + lifecycle_message = (known after apply)
+              + state             = (known after apply)
+              + stream_id         = (known after apply)
+              + topic_id          = (known after apply)
+            }
+        }
+    }
+
+  # module.functions.oci_functions_application.this will be created
+  + resource "oci_functions_application" "this" {
+      + compartment_id             = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+      + config                     = (known after apply)
+      + defined_tags               = (known after apply)
+      + display_name               = "object-events-app"
+      + freeform_tags              = (known after apply)
+      + id                         = (known after apply)
+      + network_security_group_ids = (known after apply)
+      + security_attributes        = (known after apply)
+      + shape                      = "GENERIC_X86"
+      + state                      = (known after apply)
+      + subnet_ids                 = [
+          + "ocid1.subnet.oc1..dryrun00000000000000000000000000000000000000000000000000",
+        ]
+      + syslog_url                 = (known after apply)
+      + time_created               = (known after apply)
+      + time_updated               = (known after apply)
+    }
+
+  # module.functions.oci_functions_function.this will be created
+  + resource "oci_functions_function" "this" {
+      + application_id                   = (known after apply)
+      + compartment_id                   = (known after apply)
+      + config                           = (known after apply)
+      + defined_tags                     = (known after apply)
+      + detached_mode_timeout_in_seconds = (known after apply)
+      + display_name                     = "image-processor"
+      + freeform_tags                    = (known after apply)
+      + id                               = (known after apply)
+      + image                            = "phx.ocir.io/tenancy/image:tag"
+      + image_digest                     = (known after apply)
+      + invoke_endpoint                  = (known after apply)
+      + memory_in_mbs                    = "256"
+      + shape                            = (known after apply)
+      + state                            = (known after apply)
+      + time_created                     = (known after apply)
+      + time_updated                     = (known after apply)
+      + timeout_in_seconds               = 30
+    }
+
+  # module.logging.oci_logging_log.this will be created
+  + resource "oci_logging_log" "this" {
+      + compartment_id     = (known after apply)
+      + defined_tags       = (known after apply)
+      + display_name       = "function-log"
+      + freeform_tags      = (known after apply)
+      + id                 = (known after apply)
+      + is_enabled         = (known after apply)
+      + log_group_id       = (known after apply)
+      + log_type           = "CUSTOM"
+      + retention_duration = (known after apply)
+      + state              = (known after apply)
+      + tenancy_id         = (known after apply)
+      + time_created       = (known after apply)
+      + time_last_modified = (known after apply)
+
+      + configuration {
+          + compartment_id = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+
+          + source {
+              + category    = "invoke"
+              + parameters  = (known after apply)
+              + resource    = (known after apply)
+              + service     = "functions"
+              + source_type = "OCISERVICE"
+            }
+        }
+    }
+
+  # module.logging.oci_logging_log_group.this will be created
+  + resource "oci_logging_log_group" "this" {
+      + compartment_id     = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+      + defined_tags       = (known after apply)
+      + description        = (known after apply)
+      + display_name       = "function-logs"
+      + freeform_tags      = (known after apply)
+      + id                 = (known after apply)
+      + state              = (known after apply)
+      + time_created       = (known after apply)
+      + time_last_modified = (known after apply)
+    }
+
+  # module.objectstorage.oci_objectstorage_bucket.this will be created
+  + resource "oci_objectstorage_bucket" "this" {
+      + access_type                  = "NoPublicAccess"
+      + approximate_count            = (known after apply)
+      + approximate_size             = (known after apply)
+      + auto_tiering                 = (known after apply)
+      + bucket_id                    = (known after apply)
+      + compartment_id               = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+      + created_by                   = (known after apply)
+      + defined_tags                 = (known after apply)
+      + etag                         = (known after apply)
+      + freeform_tags                = (known after apply)
+      + id                           = (known after apply)
+      + is_read_only                 = (known after apply)
+      + kms_key_id                   = (known after apply)
+      + name                         = "my-bucket"
+      + namespace                    = "my-namespace"
+      + object_events_enabled        = true
+      + object_lifecycle_policy_etag = (known after apply)
+      + replication_enabled          = (known after apply)
+      + storage_tier                 = "Standard"
+      + time_created                 = (known after apply)
+      + versioning                   = (known after apply)
+    }
+
+  # module.service_connector.oci_sch_service_connector.this will be created
+  + resource "oci_sch_service_connector" "this" {
+      + compartment_id    = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+      + defined_tags      = (known after apply)
+      + description       = (known after apply)
+      + display_name      = "function-log-connector"
+      + freeform_tags     = (known after apply)
+      + id                = (known after apply)
+      + lifecycle_details = (known after apply)
+      + lifecyle_details  = (known after apply)
+      + state             = (known after apply)
+      + system_tags       = (known after apply)
+      + time_created      = (known after apply)
+      + time_updated      = (known after apply)
+
+      + source {
+          + config_map                = (known after apply)
+          + kind                      = "logging"
+          + plugin_name               = (known after apply)
+          + private_endpoint_metadata = (known after apply)
+          + stream_id                 = (known after apply)
+
+          + log_sources {
+              + compartment_id = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+              + log_group_id   = (known after apply)
+              + log_id         = (known after apply)
+            }
+        }
+
+      + target {
+          + batch_rollover_size_in_mbs = (known after apply)
+          + batch_rollover_time_in_ms  = (known after apply)
+          + batch_size_in_kbs          = (known after apply)
+          + batch_size_in_num          = (known after apply)
+          + batch_time_in_sec          = (known after apply)
+          + bucket                     = (known after apply)
+          + compartment_id             = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
+          + enable_formatted_messaging = (known after apply)
+          + function_id                = (known after apply)
+          + kind                       = "logging"
+          + log_group_id               = (known after apply)
+          + log_source_identifier      = (known after apply)
+          + metric                     = (known after apply)
+          + metric_namespace           = (known after apply)
+          + namespace                  = (known after apply)
+          + object_name_prefix         = (known after apply)
+          + private_endpoint_metadata  = (known after apply)
+          + stream_id                  = (known after apply)
+          + topic_id                   = (known after apply)
+        }
+    }
+
+Plan: 7 to add, 0 to change, 0 to destroy.
+
+Changes to Outputs:
+  + bucket_id            = (known after apply)
+  + events_rule_id       = (known after apply)
+  + function_id          = (known after apply)
+  + log_group_id         = (known after apply)
+  + service_connector_id = (known after apply)

--- a/object-events-function-logging/variables.tf
+++ b/object-events-function-logging/variables.tf
@@ -1,0 +1,119 @@
+variable "compartment_id" {
+  type        = string
+  description = "Compartment OCID."
+}
+
+variable "vcn_id" {
+  type        = string
+  description = "Existing VCN OCID."
+}
+
+variable "function_subnet_ids" {
+  type        = list(string)
+  description = "Subnets for the Functions application."
+}
+
+variable "function_nsg_ids" {
+  type        = list(string)
+  description = "NSG IDs for the Functions application."
+  default     = []
+}
+
+variable "objectstorage_namespace" {
+  type        = string
+  description = "Object Storage namespace."
+}
+
+variable "bucket_name" {
+  type        = string
+  description = "Bucket name for object uploads."
+}
+
+variable "bucket_storage_tier" {
+  type        = string
+  description = "Storage tier for the bucket."
+  default     = "Standard"
+}
+
+variable "object_events_enabled" {
+  type        = bool
+  description = "Enable Object Storage events."
+  default     = true
+}
+
+variable "application_name" {
+  type        = string
+  description = "Functions application name."
+  default     = "object-events-app"
+}
+
+variable "application_shape" {
+  type        = string
+  description = "Functions application shape."
+  default     = "GENERIC_X86"
+}
+
+variable "function_name" {
+  type        = string
+  description = "Function name."
+  default     = "image-processor"
+}
+
+variable "function_image" {
+  type        = string
+  description = "OCIR image for the function."
+}
+
+variable "function_memory_in_mbs" {
+  type        = number
+  description = "Function memory in MB."
+  default     = 256
+}
+
+variable "function_timeout_in_seconds" {
+  type        = number
+  description = "Function timeout in seconds."
+  default     = 30
+}
+
+variable "event_rule_name" {
+  type        = string
+  description = "Events rule name."
+  default     = "object-create-events"
+}
+
+variable "event_rule_description" {
+  type        = string
+  description = "Events rule description."
+  default     = "Trigger Functions when objects are created."
+}
+
+variable "event_condition" {
+  type        = string
+  description = "Events rule condition (JSON). Leave empty to auto-generate."
+  default     = ""
+}
+
+variable "log_group_name" {
+  type        = string
+  description = "Log group name."
+  default     = "function-logs"
+}
+
+variable "log_name" {
+  type        = string
+  description = "Log name."
+  default     = "function-log"
+}
+
+variable "service_connector_name" {
+  type        = string
+  description = "Service Connector name."
+  default     = "function-log-connector"
+}
+
+variable "service_connector_target_kind" {
+  type        = string
+  description = "Service Connector target kind (e.g., logging)."
+  default     = "logging"
+}

--- a/object-events-function-logging/versions.tf
+++ b/object-events-function-logging/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = ">= 5.0.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds a new module-structured OCI Terraform template: `object-events-function-logging`.

## Module Structure
object-events-function-logging/.terraform.lock.hcl
object-events-function-logging/.terraform/modules/modules.json
object-events-function-logging/.terraform/providers/registry.terraform.io/hashicorp/oci/8.7.0/darwin_arm64/terraform-provider-oci_v8.7.0
object-events-function-logging/.terraform/providers/registry.terraform.io/oracle/oci/8.7.0/darwin_arm64/terraform-provider-oci_v8.7.0
object-events-function-logging/README.md
object-events-function-logging/main.tf
object-events-function-logging/modules/events/main.tf
object-events-function-logging/modules/events/outputs.tf
object-events-function-logging/modules/events/variables.tf
object-events-function-logging/modules/functions/main.tf
object-events-function-logging/modules/functions/outputs.tf
object-events-function-logging/modules/functions/variables.tf
object-events-function-logging/modules/logging/main.tf
object-events-function-logging/modules/logging/outputs.tf
object-events-function-logging/modules/logging/variables.tf
object-events-function-logging/modules/networking/main.tf
object-events-function-logging/modules/networking/outputs.tf
object-events-function-logging/modules/networking/variables.tf
object-events-function-logging/modules/objectstorage/main.tf
object-events-function-logging/modules/objectstorage/outputs.tf
object-events-function-logging/modules/objectstorage/variables.tf
object-events-function-logging/modules/service-connector/main.tf
object-events-function-logging/modules/service-connector/outputs.tf
object-events-function-logging/modules/service-connector/variables.tf
object-events-function-logging/outputs.tf
object-events-function-logging/plan.txt
object-events-function-logging/variables.tf
object-events-function-logging/versions.tf

## Terraform Plan
```

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  [32m+[0m create[0m

Terraform will perform the following actions:

[1m  # module.events.oci_events_rule.this[0m will be created
[0m  [32m+[0m[0m resource "oci_events_rule" "this" {
      [32m+[0m[0m compartment_id    = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
      [32m+[0m[0m condition         = jsonencode(
            {
              [32m+[0m[0m data      = {
                  [32m+[0m[0m compartmentId = [
                      [32m+[0m[0m "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000",
                    ]
                  [32m+[0m[0m resourceName  = [
                      [32m+[0m[0m "my-bucket",
                    ]
                }
              [32m+[0m[0m eventType = [
                  [32m+[0m[0m "com.oraclecloud.objectstorage.createobject",
                ]
            }
        )
      [32m+[0m[0m defined_tags      = (known after apply)
      [32m+[0m[0m description       = "Trigger Functions when objects are created."
      [32m+[0m[0m display_name      = "object-create-events"
      [32m+[0m[0m freeform_tags     = (known after apply)
      [32m+[0m[0m id                = (known after apply)
      [32m+[0m[0m is_enabled        = true
      [32m+[0m[0m lifecycle_message = (known after apply)
      [32m+[0m[0m state             = (known after apply)
      [32m+[0m[0m time_created      = (known after apply)

      [32m+[0m[0m actions {
          [32m+[0m[0m actions {
              [32m+[0m[0m action_type       = "FAAS"
              [32m+[0m[0m description       = (known after apply)
              [32m+[0m[0m function_id       = (known after apply)
              [32m+[0m[0m id                = (known after apply)
              [32m+[0m[0m is_enabled        = true
              [32m+[0m[0m lifecycle_message = (known after apply)
              [32m+[0m[0m state             = (known after apply)
              [32m+[0m[0m stream_id         = (known after apply)
              [32m+[0m[0m topic_id          = (known after apply)
            }
        }
    }

[1m  # module.functions.oci_functions_application.this[0m will be created
[0m  [32m+[0m[0m resource "oci_functions_application" "this" {
      [32m+[0m[0m compartment_id             = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
      [32m+[0m[0m config                     = (known after apply)
      [32m+[0m[0m defined_tags               = (known after apply)
      [32m+[0m[0m display_name               = "object-events-app"
      [32m+[0m[0m freeform_tags              = (known after apply)
      [32m+[0m[0m id                         = (known after apply)
      [32m+[0m[0m network_security_group_ids = (known after apply)
      [32m+[0m[0m security_attributes        = (known after apply)
      [32m+[0m[0m shape                      = "GENERIC_X86"
      [32m+[0m[0m state                      = (known after apply)
      [32m+[0m[0m subnet_ids                 = [
          [32m+[0m[0m "ocid1.subnet.oc1..dryrun00000000000000000000000000000000000000000000000000",
        ]
      [32m+[0m[0m syslog_url                 = (known after apply)
      [32m+[0m[0m time_created               = (known after apply)
      [32m+[0m[0m time_updated               = (known after apply)
    }

[1m  # module.functions.oci_functions_function.this[0m will be created
[0m  [32m+[0m[0m resource "oci_functions_function" "this" {
      [32m+[0m[0m application_id                   = (known after apply)
      [32m+[0m[0m compartment_id                   = (known after apply)
      [32m+[0m[0m config                           = (known after apply)
      [32m+[0m[0m defined_tags                     = (known after apply)
      [32m+[0m[0m detached_mode_timeout_in_seconds = (known after apply)
      [32m+[0m[0m display_name                     = "image-processor"
      [32m+[0m[0m freeform_tags                    = (known after apply)
      [32m+[0m[0m id                               = (known after apply)
      [32m+[0m[0m image                            = "phx.ocir.io/tenancy/image:tag"
      [32m+[0m[0m image_digest                     = (known after apply)
      [32m+[0m[0m invoke_endpoint                  = (known after apply)
      [32m+[0m[0m memory_in_mbs                    = "256"
      [32m+[0m[0m shape                            = (known after apply)
      [32m+[0m[0m state                            = (known after apply)
      [32m+[0m[0m time_created                     = (known after apply)
      [32m+[0m[0m time_updated                     = (known after apply)
      [32m+[0m[0m timeout_in_seconds               = 30
    }

[1m  # module.logging.oci_logging_log.this[0m will be created
[0m  [32m+[0m[0m resource "oci_logging_log" "this" {
      [32m+[0m[0m compartment_id     = (known after apply)
      [32m+[0m[0m defined_tags       = (known after apply)
      [32m+[0m[0m display_name       = "function-log"
      [32m+[0m[0m freeform_tags      = (known after apply)
      [32m+[0m[0m id                 = (known after apply)
      [32m+[0m[0m is_enabled         = (known after apply)
      [32m+[0m[0m log_group_id       = (known after apply)
      [32m+[0m[0m log_type           = "CUSTOM"
      [32m+[0m[0m retention_duration = (known after apply)
      [32m+[0m[0m state              = (known after apply)
      [32m+[0m[0m tenancy_id         = (known after apply)
      [32m+[0m[0m time_created       = (known after apply)
      [32m+[0m[0m time_last_modified = (known after apply)

      [32m+[0m[0m configuration {
          [32m+[0m[0m compartment_id = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"

          [32m+[0m[0m source {
              [32m+[0m[0m category    = "invoke"
              [32m+[0m[0m parameters  = (known after apply)
              [32m+[0m[0m resource    = (known after apply)
              [32m+[0m[0m service     = "functions"
              [32m+[0m[0m source_type = "OCISERVICE"
            }
        }
    }

[1m  # module.logging.oci_logging_log_group.this[0m will be created
[0m  [32m+[0m[0m resource "oci_logging_log_group" "this" {
      [32m+[0m[0m compartment_id     = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
      [32m+[0m[0m defined_tags       = (known after apply)
      [32m+[0m[0m description        = (known after apply)
      [32m+[0m[0m display_name       = "function-logs"
      [32m+[0m[0m freeform_tags      = (known after apply)
      [32m+[0m[0m id                 = (known after apply)
      [32m+[0m[0m state              = (known after apply)
      [32m+[0m[0m time_created       = (known after apply)
      [32m+[0m[0m time_last_modified = (known after apply)
    }

[1m  # module.objectstorage.oci_objectstorage_bucket.this[0m will be created
[0m  [32m+[0m[0m resource "oci_objectstorage_bucket" "this" {
      [32m+[0m[0m access_type                  = "NoPublicAccess"
      [32m+[0m[0m approximate_count            = (known after apply)
      [32m+[0m[0m approximate_size             = (known after apply)
      [32m+[0m[0m auto_tiering                 = (known after apply)
      [32m+[0m[0m bucket_id                    = (known after apply)
      [32m+[0m[0m compartment_id               = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
      [32m+[0m[0m created_by                   = (known after apply)
      [32m+[0m[0m defined_tags                 = (known after apply)
      [32m+[0m[0m etag                         = (known after apply)
      [32m+[0m[0m freeform_tags                = (known after apply)
      [32m+[0m[0m id                           = (known after apply)
      [32m+[0m[0m is_read_only                 = (known after apply)
      [32m+[0m[0m kms_key_id                   = (known after apply)
      [32m+[0m[0m name                         = "my-bucket"
      [32m+[0m[0m namespace                    = "my-namespace"
      [32m+[0m[0m object_events_enabled        = true
      [32m+[0m[0m object_lifecycle_policy_etag = (known after apply)
      [32m+[0m[0m replication_enabled          = (known after apply)
      [32m+[0m[0m storage_tier                 = "Standard"
      [32m+[0m[0m time_created                 = (known after apply)
      [32m+[0m[0m versioning                   = (known after apply)
    }

[1m  # module.service_connector.oci_sch_service_connector.this[0m will be created
[0m  [32m+[0m[0m resource "oci_sch_service_connector" "this" {
      [32m+[0m[0m compartment_id    = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
      [32m+[0m[0m defined_tags      = (known after apply)
      [32m+[0m[0m description       = (known after apply)
      [32m+[0m[0m display_name      = "function-log-connector"
      [32m+[0m[0m freeform_tags     = (known after apply)
      [32m+[0m[0m id                = (known after apply)
      [32m+[0m[0m lifecycle_details = (known after apply)
      [32m+[0m[0m lifecyle_details  = (known after apply)
      [32m+[0m[0m state             = (known after apply)
      [32m+[0m[0m system_tags       = (known after apply)
      [32m+[0m[0m time_created      = (known after apply)
      [32m+[0m[0m time_updated      = (known after apply)

      [32m+[0m[0m source {
          [32m+[0m[0m config_map                = (known after apply)
          [32m+[0m[0m kind                      = "logging"
          [32m+[0m[0m plugin_name               = (known after apply)
          [32m+[0m[0m private_endpoint_metadata = (known after apply)
          [32m+[0m[0m stream_id                 = (known after apply)

          [32m+[0m[0m log_sources {
              [32m+[0m[0m compartment_id = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
              [32m+[0m[0m log_group_id   = (known after apply)
              [32m+[0m[0m log_id         = (known after apply)
            }
        }

      [32m+[0m[0m target {
          [32m+[0m[0m batch_rollover_size_in_mbs = (known after apply)
          [32m+[0m[0m batch_rollover_time_in_ms  = (known after apply)
          [32m+[0m[0m batch_size_in_kbs          = (known after apply)
          [32m+[0m[0m batch_size_in_num          = (known after apply)
          [32m+[0m[0m batch_time_in_sec          = (known after apply)
          [32m+[0m[0m bucket                     = (known after apply)
          [32m+[0m[0m compartment_id             = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
          [32m+[0m[0m enable_formatted_messaging = (known after apply)
          [32m+[0m[0m function_id                = (known after apply)
          [32m+[0m[0m kind                       = "logging"
          [32m+[0m[0m log_group_id               = (known after apply)
          [32m+[0m[0m log_source_identifier      = (known after apply)
          [32m+[0m[0m metric                     = (known after apply)
          [32m+[0m[0m metric_namespace           = (known after apply)
          [32m+[0m[0m namespace                  = (known after apply)
          [32m+[0m[0m object_name_prefix         = (known after apply)
          [32m+[0m[0m private_endpoint_metadata  = (known after apply)
          [32m+[0m[0m stream_id                  = (known after apply)
          [32m+[0m[0m topic_id                   = (known after apply)
        }
    }

[1mPlan:[0m 7 to add, 0 to change, 0 to destroy.
[0m
Changes to Outputs:
  [32m+[0m[0m bucket_id            = (known after apply)
  [32m+[0m[0m events_rule_id       = (known after apply)
  [32m+[0m[0m function_id          = (known after apply)
  [32m+[0m[0m log_group_id         = (known after apply)
  [32m+[0m[0m service_connector_id = (known after apply)
[90m
─────────────────────────────────────────────────────────────────────────────[0m

Saved the plan to: plan.out

To perform exactly these actions, run the following command to apply:
    terraform apply "plan.out"

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.events.oci_events_rule.this will be created
  + resource "oci_events_rule" "this" {
      + compartment_id    = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
      + condition         = jsonencode(
            {
              + data      = {
                  + compartmentId = [
                      + "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000",
                    ]
                  + resourceName  = [
                      + "my-bucket",
                    ]
                }
              + eventType = [
                  + "com.oraclecloud.objectstorage.createobject",
                ]
            }
        )
      + defined_tags      = (known after apply)
      + description       = "Trigger Functions when objects are created."
      + display_name      = "object-create-events"
      + freeform_tags     = (known after apply)
      + id                = (known after apply)
      + is_enabled        = true
      + lifecycle_message = (known after apply)
      + state             = (known after apply)
      + time_created      = (known after apply)

      + actions {
          + actions {
              + action_type       = "FAAS"
              + description       = (known after apply)
              + function_id       = (known after apply)
              + id                = (known after apply)
              + is_enabled        = true
              + lifecycle_message = (known after apply)
              + state             = (known after apply)
              + stream_id         = (known after apply)
              + topic_id          = (known after apply)
            }
        }
    }

  # module.functions.oci_functions_application.this will be created
  + resource "oci_functions_application" "this" {
      + compartment_id             = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
      + config                     = (known after apply)
      + defined_tags               = (known after apply)
      + display_name               = "object-events-app"
      + freeform_tags              = (known after apply)
      + id                         = (known after apply)
      + network_security_group_ids = (known after apply)
      + security_attributes        = (known after apply)
      + shape                      = "GENERIC_X86"
      + state                      = (known after apply)
      + subnet_ids                 = [
          + "ocid1.subnet.oc1..dryrun00000000000000000000000000000000000000000000000000",
        ]
      + syslog_url                 = (known after apply)
      + time_created               = (known after apply)
      + time_updated               = (known after apply)
    }

  # module.functions.oci_functions_function.this will be created
  + resource "oci_functions_function" "this" {
      + application_id                   = (known after apply)
      + compartment_id                   = (known after apply)
      + config                           = (known after apply)
      + defined_tags                     = (known after apply)
      + detached_mode_timeout_in_seconds = (known after apply)
      + display_name                     = "image-processor"
      + freeform_tags                    = (known after apply)
      + id                               = (known after apply)
      + image                            = "phx.ocir.io/tenancy/image:tag"
      + image_digest                     = (known after apply)
      + invoke_endpoint                  = (known after apply)
      + memory_in_mbs                    = "256"
      + shape                            = (known after apply)
      + state                            = (known after apply)
      + time_created                     = (known after apply)
      + time_updated                     = (known after apply)
      + timeout_in_seconds               = 30
    }

  # module.logging.oci_logging_log.this will be created
  + resource "oci_logging_log" "this" {
      + compartment_id     = (known after apply)
      + defined_tags       = (known after apply)
      + display_name       = "function-log"
      + freeform_tags      = (known after apply)
      + id                 = (known after apply)
      + is_enabled         = (known after apply)
      + log_group_id       = (known after apply)
      + log_type           = "CUSTOM"
      + retention_duration = (known after apply)
      + state              = (known after apply)
      + tenancy_id         = (known after apply)
      + time_created       = (known after apply)
      + time_last_modified = (known after apply)

      + configuration {
          + compartment_id = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"

          + source {
              + category    = "invoke"
              + parameters  = (known after apply)
              + resource    = (known after apply)
              + service     = "functions"
              + source_type = "OCISERVICE"
            }
        }
    }

  # module.logging.oci_logging_log_group.this will be created
  + resource "oci_logging_log_group" "this" {
      + compartment_id     = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
      + defined_tags       = (known after apply)
      + description        = (known after apply)
      + display_name       = "function-logs"
      + freeform_tags      = (known after apply)
      + id                 = (known after apply)
      + state              = (known after apply)
      + time_created       = (known after apply)
      + time_last_modified = (known after apply)
    }

  # module.objectstorage.oci_objectstorage_bucket.this will be created
  + resource "oci_objectstorage_bucket" "this" {
      + access_type                  = "NoPublicAccess"
      + approximate_count            = (known after apply)
      + approximate_size             = (known after apply)
      + auto_tiering                 = (known after apply)
      + bucket_id                    = (known after apply)
      + compartment_id               = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
      + created_by                   = (known after apply)
      + defined_tags                 = (known after apply)
      + etag                         = (known after apply)
      + freeform_tags                = (known after apply)
      + id                           = (known after apply)
      + is_read_only                 = (known after apply)
      + kms_key_id                   = (known after apply)
      + name                         = "my-bucket"
      + namespace                    = "my-namespace"
      + object_events_enabled        = true
      + object_lifecycle_policy_etag = (known after apply)
      + replication_enabled          = (known after apply)
      + storage_tier                 = "Standard"
      + time_created                 = (known after apply)
      + versioning                   = (known after apply)
    }

  # module.service_connector.oci_sch_service_connector.this will be created
  + resource "oci_sch_service_connector" "this" {
      + compartment_id    = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
      + defined_tags      = (known after apply)
      + description       = (known after apply)
      + display_name      = "function-log-connector"
      + freeform_tags     = (known after apply)
      + id                = (known after apply)
      + lifecycle_details = (known after apply)
      + lifecyle_details  = (known after apply)
      + state             = (known after apply)
      + system_tags       = (known after apply)
      + time_created      = (known after apply)
      + time_updated      = (known after apply)

      + source {
          + config_map                = (known after apply)
          + kind                      = "logging"
          + plugin_name               = (known after apply)
          + private_endpoint_metadata = (known after apply)
          + stream_id                 = (known after apply)

          + log_sources {
              + compartment_id = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
              + log_group_id   = (known after apply)
              + log_id         = (known after apply)
            }
        }

      + target {
          + batch_rollover_size_in_mbs = (known after apply)
          + batch_rollover_time_in_ms  = (known after apply)
          + batch_size_in_kbs          = (known after apply)
          + batch_size_in_num          = (known after apply)
          + batch_time_in_sec          = (known after apply)
          + bucket                     = (known after apply)
          + compartment_id             = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000000000000"
          + enable_formatted_messaging = (known after apply)
          + function_id                = (known after apply)
          + kind                       = "logging"
          + log_group_id               = (known after apply)
          + log_source_identifier      = (known after apply)
          + metric                     = (known after apply)
          + metric_namespace           = (known after apply)
          + namespace                  = (known after apply)
          + object_name_prefix         = (known after apply)
          + private_endpoint_metadata  = (known after apply)
          + stream_id                  = (known after apply)
          + topic_id                   = (known after apply)
        }
    }

Plan: 7 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + bucket_id            = (known after apply)
  + events_rule_id       = (known after apply)
  + function_id          = (known after apply)
  + log_group_id         = (known after apply)
  + service_connector_id = (known after apply)
```