### PR TITLE
feat: add OCI Terraform template — logs-streaming-kafka-splunk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+dry-run.*

--- a/logs-streaming-kafka-splunk/.terraform.lock.hcl
+++ b/logs-streaming-kafka-splunk/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/oracle/oci" {
+  version     = "8.8.0"
+  constraints = ">= 5.0.0"
+  hashes = [
+    "h1:3kbLMkY+1zJDaBkDlpH7nhE38fezpxWLayq0dWTz8Zk=",
+    "zh:123a2a31187ee553f20b77eb5a66c5e85212c4ecfdbb2318f5d4ddb0d53db02d",
+    "zh:49e08e1b5f22d8919e7a0a80869296ef2fde2681760e72c4520b14b9e21fe84c",
+    "zh:4e4b613a29a24c7629ee51b0d9b41d5ec1a745ea056f2fec2e2cf02ebc42d47f",
+    "zh:636c7723618030f1c67262ac6232abc30da24cc75fdb84671f754fccbcae64de",
+    "zh:72dba7a6351ba6e024c5f5f39c3fd7e2ecc826ef9b1040ea51ca060eb5f1f25a",
+    "zh:74f06a582ebda797f27cb3140ee3a156c3ac408261f561ac1285da840f4f6310",
+    "zh:75d26046e6a33d6d1e1a9271d527f8652b9de52b4e2ad3ea079b42c7341f0bcb",
+    "zh:79a422159c6a948e5b87e34097a447f8bf44c44c88edf42fc08024df4c0817ac",
+    "zh:954122b275c88ada08be58246defa9b9ffe684c3ec79a747f917315b7ec7506d",
+    "zh:9576da25f2a064d1c66e0af9dd75ea632c343793aae1c1ff91ef97c1c5d6d893",
+    "zh:95d1c585401edcd59860a00c87219305e8a69901a2c2379bc9ad5f493c528918",
+    "zh:98b9e7cff79c11a302a4f7a00719c8850e9d543640d7a5c55aaac9b1a714b575",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:cda99eb4a652a8156ee3a74c33ce2ffee4194c8a2cd837163fb62557d7cb481b",
+    "zh:e261e596697456d565e9528e566826bf246718665750d89814e96f8e3404ac09",
+  ]
+}

--- a/logs-streaming-kafka-splunk/README.md
+++ b/logs-streaming-kafka-splunk/README.md
@@ -1,0 +1,138 @@
+# Stream OCI logs to OCI Streaming (Kafka compatible) for Splunk
+
+This template creates an OCI Logging log group and log, a Streaming pool and stream, and a Service Connector Hub connector to move logs into the stream for downstream Kafka Connect (Splunk) consumption.
+
+## Module Structure
+
+```
+logs-streaming-kafka-splunk/
+├── main.tf
+├── variables.tf
+├── outputs.tf
+├── versions.tf
+├── README.md
+└── modules/
+    ├── logging/
+    │   ├── main.tf
+    │   ├── variables.tf
+    │   ├── outputs.tf
+    │   └── versions.tf
+    ├── streaming/
+    │   ├── main.tf
+    │   ├── variables.tf
+    │   ├── outputs.tf
+    │   └── versions.tf
+    └── service-connector/
+        ├── main.tf
+        ├── variables.tf
+        ├── outputs.tf
+        └── versions.tf
+```
+
+## Prerequisites
+
+- OCI tenancy with permissions to manage Logging, Streaming, and Service Connector Hub.
+- IAM policies (example):
+  - Allow group <group> to manage log-groups in compartment <compartment>
+  - Allow group <group> to manage logs in compartment <compartment>
+  - Allow group <group> to manage stream-pools in compartment <compartment>
+  - Allow group <group> to manage streams in compartment <compartment>
+  - Allow group <group> to manage service-connectors in compartment <compartment>
+
+## Usage
+
+```hcl
+module "logs_streaming_kafka_splunk" {
+  source = "./logs-streaming-kafka-splunk"
+
+  compartment_id               = var.compartment_id
+  log_group_display_name       = var.log_group_display_name
+  log_group_description        = var.log_group_description
+  log_display_name             = var.log_display_name
+  log_type                     = var.log_type
+  log_is_enabled               = var.log_is_enabled
+  log_retention_duration       = var.log_retention_duration
+  log_source_category          = var.log_source_category
+  log_source_resource          = var.log_source_resource
+  log_source_service           = var.log_source_service
+  log_source_type              = var.log_source_type
+  log_source_parameters        = var.log_source_parameters
+
+  stream_pool_name             = var.stream_pool_name
+  stream_name                  = var.stream_name
+  stream_partitions            = var.stream_partitions
+  stream_retention_hours       = var.stream_retention_hours
+  kafka_auto_create_topics     = var.kafka_auto_create_topics
+  kafka_log_retention_hours    = var.kafka_log_retention_hours
+  kafka_default_partitions     = var.kafka_default_partitions
+
+  service_connector_display_name = var.service_connector_display_name
+  service_connector_description  = var.service_connector_description
+  log_source_compartment_id      = var.log_source_compartment_id
+
+  freeform_tags                = var.freeform_tags
+  defined_tags                 = var.defined_tags
+}
+```
+
+## Input Variables
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| compartment_id | OCID of the compartment where resources are created. | string | n/a | yes |
+| log_group_display_name | Display name for the log group. | string | n/a | yes |
+| log_group_description | Description for the log group. | string | "Log group for streaming log pipeline" | no |
+| log_display_name | Display name for the log. | string | n/a | yes |
+| log_type | Log type (SERVICE or CUSTOM). | string | "SERVICE" | no |
+| log_is_enabled | Whether the log is enabled. | bool | true | no |
+| log_retention_duration | Retention duration for logs in days (30, 60, 90, 120, 150, 180). | number | 30 | no |
+| log_source_category | Log source category for the logging service. | string | n/a | yes |
+| log_source_resource | OCID of the resource emitting logs. | string | n/a | yes |
+| log_source_service | Service generating logs (e.g., objectstorage). | string | n/a | yes |
+| log_source_type | Log source type (OCISERVICE). | string | "OCISERVICE" | no |
+| log_source_parameters | Optional log source parameters for OCI service logs. | map(string) | {} | no |
+| stream_pool_name | Name for the streaming pool. | string | n/a | yes |
+| stream_name | Name for the stream. | string | n/a | yes |
+| stream_partitions | Number of partitions for the stream. | number | 1 | no |
+| stream_retention_hours | Retention period for the stream in hours. | number | 24 | no |
+| kafka_auto_create_topics | Enable auto topic creation for Kafka compatibility. | bool | true | no |
+| kafka_log_retention_hours | Default Kafka log retention in hours. | number | 24 | no |
+| kafka_default_partitions | Default Kafka partitions for new topics. | number | 1 | no |
+| service_connector_display_name | Display name for the service connector. | string | n/a | yes |
+| service_connector_description | Description for the service connector. | string | "Logging to Streaming connector" | no |
+| log_source_compartment_id | Compartment OCID containing the log sources. | string | n/a | yes |
+| freeform_tags | Freeform tags to apply to resources. | map(string) | {} | no |
+| defined_tags | Defined tags to apply to resources. | map(string) | {} | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| log_group_id | OCID of the log group. |
+| log_id | OCID of the log. |
+| stream_pool_id | OCID of the stream pool. |
+| stream_id | OCID of the stream. |
+| service_connector_id | OCID of the service connector. |
+
+## Module Details
+
+### logging
+Creates the log group and log that act as the source for the Service Connector.
+
+**Inputs:** compartment_id, log_group_display_name, log_group_description, log_display_name, log_type, log_is_enabled, log_retention_duration, log_source_category, log_source_resource, log_source_service, log_source_type, log_source_parameters, freeform_tags, defined_tags
+
+**Outputs:** log_group_id, log_id
+
+### streaming
+Creates the stream pool and stream to receive logs for Kafka Connect to Splunk.
+
+**Inputs:** compartment_id, stream_pool_name, stream_name, stream_partitions, stream_retention_hours, kafka_auto_create_topics, kafka_log_retention_hours, kafka_default_partitions, freeform_tags, defined_tags
+
+**Outputs:** stream_pool_id, stream_id
+
+### service-connector
+Creates the Service Connector Hub connector to move logs to the stream.
+
+**Inputs:** compartment_id, service_connector_display_name, service_connector_description, log_source_compartment_id, log_group_id, log_id, stream_id, freeform_tags, defined_tags
+
+**Outputs:** service_connector_id

--- a/logs-streaming-kafka-splunk/main.tf
+++ b/logs-streaming-kafka-splunk/main.tf
@@ -1,0 +1,46 @@
+provider "oci" {}
+
+module "logging" {
+  source                 = "./modules/logging"
+  compartment_id         = var.compartment_id
+  log_group_display_name = var.log_group_display_name
+  log_group_description  = var.log_group_description
+  log_display_name       = var.log_display_name
+  log_type               = var.log_type
+  log_is_enabled         = var.log_is_enabled
+  log_retention_duration = var.log_retention_duration
+  log_source_category    = var.log_source_category
+  log_source_resource    = var.log_source_resource
+  log_source_service     = var.log_source_service
+  log_source_type        = var.log_source_type
+  log_source_parameters  = var.log_source_parameters
+  freeform_tags          = var.freeform_tags
+  defined_tags           = var.defined_tags
+}
+
+module "streaming" {
+  source                   = "./modules/streaming"
+  compartment_id           = var.compartment_id
+  stream_pool_name          = var.stream_pool_name
+  stream_name               = var.stream_name
+  stream_partitions         = var.stream_partitions
+  stream_retention_hours    = var.stream_retention_hours
+  kafka_auto_create_topics  = var.kafka_auto_create_topics
+  kafka_log_retention_hours = var.kafka_log_retention_hours
+  kafka_default_partitions  = var.kafka_default_partitions
+  freeform_tags             = var.freeform_tags
+  defined_tags              = var.defined_tags
+}
+
+module "service_connector" {
+  source                         = "./modules/service-connector"
+  compartment_id                 = var.compartment_id
+  service_connector_display_name = var.service_connector_display_name
+  service_connector_description  = var.service_connector_description
+  log_source_compartment_id      = var.log_source_compartment_id
+  log_group_id                   = module.logging.log_group_id
+  log_id                         = module.logging.log_id
+  stream_id                      = module.streaming.stream_id
+  freeform_tags                  = var.freeform_tags
+  defined_tags                   = var.defined_tags
+}

--- a/logs-streaming-kafka-splunk/modules/logging/main.tf
+++ b/logs-streaming-kafka-splunk/modules/logging/main.tf
@@ -1,0 +1,34 @@
+# Log group and log definition for OCI Logging service
+resource "oci_logging_log_group" "this" {
+  compartment_id = var.compartment_id
+  display_name   = var.log_group_display_name
+  description    = var.log_group_description
+
+  freeform_tags = var.freeform_tags
+  defined_tags  = var.defined_tags
+}
+
+# Log definition that will be used as the Service Connector source
+resource "oci_logging_log" "this" {
+  display_name = var.log_display_name
+  log_group_id = oci_logging_log_group.this.id
+  log_type     = var.log_type
+  is_enabled   = var.log_is_enabled
+
+  retention_duration = var.log_retention_duration
+
+  configuration {
+    source {
+      category    = var.log_source_category
+      resource    = var.log_source_resource
+      service     = var.log_source_service
+      source_type = var.log_source_type
+      parameters  = var.log_source_parameters
+    }
+
+    compartment_id = var.compartment_id
+  }
+
+  freeform_tags = var.freeform_tags
+  defined_tags  = var.defined_tags
+}

--- a/logs-streaming-kafka-splunk/modules/logging/outputs.tf
+++ b/logs-streaming-kafka-splunk/modules/logging/outputs.tf
@@ -1,0 +1,9 @@
+output "log_group_id" {
+  description = "OCID of the log group."
+  value       = oci_logging_log_group.this.id
+}
+
+output "log_id" {
+  description = "OCID of the log."
+  value       = oci_logging_log.this.id
+}

--- a/logs-streaming-kafka-splunk/modules/logging/variables.tf
+++ b/logs-streaming-kafka-splunk/modules/logging/variables.tf
@@ -1,0 +1,77 @@
+variable "compartment_id" {
+  description = "OCID of the compartment where logging resources are created."
+  type        = string
+}
+
+variable "log_group_display_name" {
+  description = "Display name for the log group."
+  type        = string
+}
+
+variable "log_group_description" {
+  description = "Description for the log group."
+  type        = string
+  default     = "Log group for streaming log pipeline"
+}
+
+variable "log_display_name" {
+  description = "Display name for the log."
+  type        = string
+}
+
+variable "log_type" {
+  description = "Log type (SERVICE or CUSTOM)."
+  type        = string
+  default     = "SERVICE"
+}
+
+variable "log_is_enabled" {
+  description = "Whether the log is enabled."
+  type        = bool
+  default     = true
+}
+
+variable "log_retention_duration" {
+  description = "Retention duration for logs in days (30, 60, 90, 120, 150, 180)."
+  type        = number
+  default     = 30
+}
+
+variable "log_source_category" {
+  description = "Log source category for the logging service."
+  type        = string
+}
+
+variable "log_source_resource" {
+  description = "OCID of the resource emitting logs."
+  type        = string
+}
+
+variable "log_source_service" {
+  description = "Service generating logs (e.g., objectstorage)."
+  type        = string
+}
+
+variable "log_source_type" {
+  description = "Log source type (OCISERVICE)."
+  type        = string
+  default     = "OCISERVICE"
+}
+
+variable "log_source_parameters" {
+  description = "Optional log source parameters for OCI service logs."
+  type        = map(string)
+  default     = {}
+}
+
+variable "freeform_tags" {
+  description = "Freeform tags to apply to logging resources."
+  type        = map(string)
+  default     = {}
+}
+
+variable "defined_tags" {
+  description = "Defined tags to apply to logging resources."
+  type        = map(string)
+  default     = {}
+}

--- a/logs-streaming-kafka-splunk/modules/logging/versions.tf
+++ b/logs-streaming-kafka-splunk/modules/logging/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = ">= 5.0.0"
+    }
+  }
+}

--- a/logs-streaming-kafka-splunk/modules/service-connector/main.tf
+++ b/logs-streaming-kafka-splunk/modules/service-connector/main.tf
@@ -1,0 +1,24 @@
+# Service Connector Hub connector from Logging to Streaming
+resource "oci_sch_service_connector" "this" {
+  compartment_id = var.compartment_id
+  display_name   = var.service_connector_display_name
+  description    = var.service_connector_description
+
+  source {
+    kind = "logging"
+
+    log_sources {
+      compartment_id = var.log_source_compartment_id
+      log_group_id   = var.log_group_id
+      log_id         = var.log_id
+    }
+  }
+
+  target {
+    kind      = "streaming"
+    stream_id = var.stream_id
+  }
+
+  freeform_tags = var.freeform_tags
+  defined_tags  = var.defined_tags
+}

--- a/logs-streaming-kafka-splunk/modules/service-connector/outputs.tf
+++ b/logs-streaming-kafka-splunk/modules/service-connector/outputs.tf
@@ -1,0 +1,4 @@
+output "service_connector_id" {
+  description = "OCID of the service connector."
+  value       = oci_sch_service_connector.this.id
+}

--- a/logs-streaming-kafka-splunk/modules/service-connector/variables.tf
+++ b/logs-streaming-kafka-splunk/modules/service-connector/variables.tf
@@ -1,0 +1,47 @@
+variable "compartment_id" {
+  description = "OCID of the compartment where the service connector is created."
+  type        = string
+}
+
+variable "service_connector_display_name" {
+  description = "Display name for the service connector."
+  type        = string
+}
+
+variable "service_connector_description" {
+  description = "Description for the service connector."
+  type        = string
+  default     = "Logging to Streaming connector"
+}
+
+variable "log_source_compartment_id" {
+  description = "Compartment OCID containing the log sources."
+  type        = string
+}
+
+variable "log_group_id" {
+  description = "OCID of the log group used as the source."
+  type        = string
+}
+
+variable "log_id" {
+  description = "OCID of the log used as the source."
+  type        = string
+}
+
+variable "stream_id" {
+  description = "OCID of the streaming stream used as the target."
+  type        = string
+}
+
+variable "freeform_tags" {
+  description = "Freeform tags to apply to the service connector."
+  type        = map(string)
+  default     = {}
+}
+
+variable "defined_tags" {
+  description = "Defined tags to apply to the service connector."
+  type        = map(string)
+  default     = {}
+}

--- a/logs-streaming-kafka-splunk/modules/service-connector/versions.tf
+++ b/logs-streaming-kafka-splunk/modules/service-connector/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = ">= 5.0.0"
+    }
+  }
+}

--- a/logs-streaming-kafka-splunk/modules/streaming/main.tf
+++ b/logs-streaming-kafka-splunk/modules/streaming/main.tf
@@ -1,0 +1,25 @@
+# Stream pool for Kafka-compatible OCI Streaming
+resource "oci_streaming_stream_pool" "this" {
+  compartment_id = var.compartment_id
+  name           = var.stream_pool_name
+
+  kafka_settings {
+    auto_create_topics_enable = var.kafka_auto_create_topics
+    log_retention_hours       = var.kafka_log_retention_hours
+    num_partitions            = var.kafka_default_partitions
+  }
+
+  freeform_tags = var.freeform_tags
+  defined_tags  = var.defined_tags
+}
+
+# Stream that will receive logs from Service Connector Hub
+resource "oci_streaming_stream" "this" {
+  name               = var.stream_name
+  partitions         = var.stream_partitions
+  retention_in_hours = var.stream_retention_hours
+  stream_pool_id     = oci_streaming_stream_pool.this.id
+
+  freeform_tags = var.freeform_tags
+  defined_tags  = var.defined_tags
+}

--- a/logs-streaming-kafka-splunk/modules/streaming/outputs.tf
+++ b/logs-streaming-kafka-splunk/modules/streaming/outputs.tf
@@ -1,0 +1,9 @@
+output "stream_pool_id" {
+  description = "OCID of the stream pool."
+  value       = oci_streaming_stream_pool.this.id
+}
+
+output "stream_id" {
+  description = "OCID of the stream."
+  value       = oci_streaming_stream.this.id
+}

--- a/logs-streaming-kafka-splunk/modules/streaming/variables.tf
+++ b/logs-streaming-kafka-splunk/modules/streaming/variables.tf
@@ -1,0 +1,56 @@
+variable "compartment_id" {
+  description = "OCID of the compartment where streaming resources are created."
+  type        = string
+}
+
+variable "stream_pool_name" {
+  description = "Name of the streaming pool."
+  type        = string
+}
+
+variable "stream_name" {
+  description = "Name of the stream receiving logs."
+  type        = string
+}
+
+variable "stream_partitions" {
+  description = "Number of partitions for the stream."
+  type        = number
+  default     = 1
+}
+
+variable "stream_retention_hours" {
+  description = "Retention period for the stream in hours."
+  type        = number
+  default     = 24
+}
+
+variable "kafka_auto_create_topics" {
+  description = "Enable auto topic creation for Kafka compatibility."
+  type        = bool
+  default     = true
+}
+
+variable "kafka_log_retention_hours" {
+  description = "Default Kafka log retention in hours."
+  type        = number
+  default     = 24
+}
+
+variable "kafka_default_partitions" {
+  description = "Default Kafka partitions for new topics."
+  type        = number
+  default     = 1
+}
+
+variable "freeform_tags" {
+  description = "Freeform tags to apply to streaming resources."
+  type        = map(string)
+  default     = {}
+}
+
+variable "defined_tags" {
+  description = "Defined tags to apply to streaming resources."
+  type        = map(string)
+  default     = {}
+}

--- a/logs-streaming-kafka-splunk/modules/streaming/versions.tf
+++ b/logs-streaming-kafka-splunk/modules/streaming/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = ">= 5.0.0"
+    }
+  }
+}

--- a/logs-streaming-kafka-splunk/outputs.tf
+++ b/logs-streaming-kafka-splunk/outputs.tf
@@ -1,0 +1,24 @@
+output "log_group_id" {
+  description = "OCID of the log group."
+  value       = module.logging.log_group_id
+}
+
+output "log_id" {
+  description = "OCID of the log."
+  value       = module.logging.log_id
+}
+
+output "stream_pool_id" {
+  description = "OCID of the stream pool."
+  value       = module.streaming.stream_pool_id
+}
+
+output "stream_id" {
+  description = "OCID of the stream."
+  value       = module.streaming.stream_id
+}
+
+output "service_connector_id" {
+  description = "OCID of the service connector."
+  value       = module.service_connector.service_connector_id
+}

--- a/logs-streaming-kafka-splunk/plan.txt
+++ b/logs-streaming-kafka-splunk/plan.txt
@@ -1,0 +1,301 @@
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  [32m+[0m create[0m
+
+Terraform will perform the following actions:
+
+[1m  # module.logging.oci_logging_log.this[0m will be created
+[0m  [32m+[0m[0m resource "oci_logging_log" "this" {
+      [32m+[0m[0m compartment_id     = (known after apply)
+      [32m+[0m[0m defined_tags       = (known after apply)
+      [32m+[0m[0m display_name       = "dry-run-log_display_name"
+      [32m+[0m[0m freeform_tags      = (known after apply)
+      [32m+[0m[0m id                 = (known after apply)
+      [32m+[0m[0m is_enabled         = true
+      [32m+[0m[0m log_group_id       = (known after apply)
+      [32m+[0m[0m log_type           = "SERVICE"
+      [32m+[0m[0m retention_duration = 30
+      [32m+[0m[0m state              = (known after apply)
+      [32m+[0m[0m tenancy_id         = (known after apply)
+      [32m+[0m[0m time_created       = (known after apply)
+      [32m+[0m[0m time_last_modified = (known after apply)
+
+      [32m+[0m[0m configuration {
+          [32m+[0m[0m compartment_id = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000"
+
+          [32m+[0m[0m source {
+              [32m+[0m[0m category    = "dummy-log_source_category"
+              [32m+[0m[0m parameters  = (known after apply)
+              [32m+[0m[0m resource    = "dummy-log_source_resource"
+              [32m+[0m[0m service     = "dummy-log_source_service"
+              [32m+[0m[0m source_type = "OCISERVICE"
+            }
+        }
+    }
+
+[1m  # module.logging.oci_logging_log_group.this[0m will be created
+[0m  [32m+[0m[0m resource "oci_logging_log_group" "this" {
+      [32m+[0m[0m compartment_id     = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000"
+      [32m+[0m[0m defined_tags       = (known after apply)
+      [32m+[0m[0m description        = "Log group for streaming log pipeline"
+      [32m+[0m[0m display_name       = "dry-run-log_group_display_name"
+      [32m+[0m[0m freeform_tags      = (known after apply)
+      [32m+[0m[0m id                 = (known after apply)
+      [32m+[0m[0m state              = (known after apply)
+      [32m+[0m[0m time_created       = (known after apply)
+      [32m+[0m[0m time_last_modified = (known after apply)
+    }
+
+[1m  # module.service_connector.oci_sch_service_connector.this[0m will be created
+[0m  [32m+[0m[0m resource "oci_sch_service_connector" "this" {
+      [32m+[0m[0m compartment_id    = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000"
+      [32m+[0m[0m defined_tags      = (known after apply)
+      [32m+[0m[0m description       = "Logging to Streaming connector"
+      [32m+[0m[0m display_name      = "dry-run-service_connector_display_name"
+      [32m+[0m[0m freeform_tags     = (known after apply)
+      [32m+[0m[0m id                = (known after apply)
+      [32m+[0m[0m lifecycle_details = (known after apply)
+      [32m+[0m[0m lifecyle_details  = (known after apply)
+      [32m+[0m[0m state             = (known after apply)
+      [32m+[0m[0m system_tags       = (known after apply)
+      [32m+[0m[0m time_created      = (known after apply)
+      [32m+[0m[0m time_updated      = (known after apply)
+
+      [32m+[0m[0m source {
+          [32m+[0m[0m config_map                = (known after apply)
+          [32m+[0m[0m kind                      = "logging"
+          [32m+[0m[0m plugin_name               = (known after apply)
+          [32m+[0m[0m private_endpoint_metadata = (known after apply)
+          [32m+[0m[0m stream_id                 = (known after apply)
+
+          [32m+[0m[0m log_sources {
+              [32m+[0m[0m compartment_id = "ocid1.log_source_compartment.oc1..dryrun0000000000000000000000000000000000000000"
+              [32m+[0m[0m log_group_id   = (known after apply)
+              [32m+[0m[0m log_id         = (known after apply)
+            }
+        }
+
+      [32m+[0m[0m target {
+          [32m+[0m[0m batch_rollover_size_in_mbs = (known after apply)
+          [32m+[0m[0m batch_rollover_time_in_ms  = (known after apply)
+          [32m+[0m[0m batch_size_in_kbs          = (known after apply)
+          [32m+[0m[0m batch_size_in_num          = (known after apply)
+          [32m+[0m[0m batch_time_in_sec          = (known after apply)
+          [32m+[0m[0m bucket                     = (known after apply)
+          [32m+[0m[0m compartment_id             = (known after apply)
+          [32m+[0m[0m enable_formatted_messaging = (known after apply)
+          [32m+[0m[0m function_id                = (known after apply)
+          [32m+[0m[0m kind                       = "streaming"
+          [32m+[0m[0m log_group_id               = (known after apply)
+          [32m+[0m[0m log_source_identifier      = (known after apply)
+          [32m+[0m[0m metric                     = (known after apply)
+          [32m+[0m[0m metric_namespace           = (known after apply)
+          [32m+[0m[0m namespace                  = (known after apply)
+          [32m+[0m[0m object_name_prefix         = (known after apply)
+          [32m+[0m[0m private_endpoint_metadata  = (known after apply)
+          [32m+[0m[0m stream_id                  = (known after apply)
+          [32m+[0m[0m topic_id                   = (known after apply)
+        }
+    }
+
+[1m  # module.streaming.oci_streaming_stream.this[0m will be created
+[0m  [32m+[0m[0m resource "oci_streaming_stream" "this" {
+      [32m+[0m[0m compartment_id          = (known after apply)
+      [32m+[0m[0m defined_tags            = (known after apply)
+      [32m+[0m[0m freeform_tags           = (known after apply)
+      [32m+[0m[0m id                      = (known after apply)
+      [32m+[0m[0m lifecycle_state_details = (known after apply)
+      [32m+[0m[0m messages_endpoint       = (known after apply)
+      [32m+[0m[0m name                    = "dry-run-stream_name"
+      [32m+[0m[0m partitions              = 1
+      [32m+[0m[0m retention_in_hours      = 24
+      [32m+[0m[0m state                   = (known after apply)
+      [32m+[0m[0m stream_pool_id          = (known after apply)
+      [32m+[0m[0m time_created            = (known after apply)
+    }
+
+[1m  # module.streaming.oci_streaming_stream_pool.this[0m will be created
+[0m  [32m+[0m[0m resource "oci_streaming_stream_pool" "this" {
+      [32m+[0m[0m compartment_id          = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000"
+      [32m+[0m[0m defined_tags            = (known after apply)
+      [32m+[0m[0m endpoint_fqdn           = (known after apply)
+      [32m+[0m[0m freeform_tags           = (known after apply)
+      [32m+[0m[0m id                      = (known after apply)
+      [32m+[0m[0m is_private              = (known after apply)
+      [32m+[0m[0m lifecycle_state_details = (known after apply)
+      [32m+[0m[0m name                    = "dry-run-stream_pool_name"
+      [32m+[0m[0m security_attributes     = (known after apply)
+      [32m+[0m[0m state                   = (known after apply)
+      [32m+[0m[0m time_created            = (known after apply)
+
+      [32m+[0m[0m kafka_settings {
+          [32m+[0m[0m auto_create_topics_enable = true
+          [32m+[0m[0m bootstrap_servers         = (known after apply)
+          [32m+[0m[0m log_retention_hours       = 24
+          [32m+[0m[0m num_partitions            = 1
+        }
+    }
+
+[1mPlan:[0m 5 to add, 0 to change, 0 to destroy.
+[0m
+Changes to Outputs:
+  [32m+[0m[0m log_group_id         = (known after apply)
+  [32m+[0m[0m log_id               = (known after apply)
+  [32m+[0m[0m service_connector_id = (known after apply)
+  [32m+[0m[0m stream_id            = (known after apply)
+  [32m+[0m[0m stream_pool_id       = (known after apply)
+[90m
+─────────────────────────────────────────────────────────────────────────────[0m
+
+Saved the plan to: plan.out
+
+To perform exactly these actions, run the following command to apply:
+    terraform apply "plan.out"
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # module.logging.oci_logging_log.this will be created
+  + resource "oci_logging_log" "this" {
+      + compartment_id     = (known after apply)
+      + defined_tags       = (known after apply)
+      + display_name       = "dry-run-log_display_name"
+      + freeform_tags      = (known after apply)
+      + id                 = (known after apply)
+      + is_enabled         = true
+      + log_group_id       = (known after apply)
+      + log_type           = "SERVICE"
+      + retention_duration = 30
+      + state              = (known after apply)
+      + tenancy_id         = (known after apply)
+      + time_created       = (known after apply)
+      + time_last_modified = (known after apply)
+
+      + configuration {
+          + compartment_id = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000"
+
+          + source {
+              + category    = "dummy-log_source_category"
+              + parameters  = (known after apply)
+              + resource    = "dummy-log_source_resource"
+              + service     = "dummy-log_source_service"
+              + source_type = "OCISERVICE"
+            }
+        }
+    }
+
+  # module.logging.oci_logging_log_group.this will be created
+  + resource "oci_logging_log_group" "this" {
+      + compartment_id     = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000"
+      + defined_tags       = (known after apply)
+      + description        = "Log group for streaming log pipeline"
+      + display_name       = "dry-run-log_group_display_name"
+      + freeform_tags      = (known after apply)
+      + id                 = (known after apply)
+      + state              = (known after apply)
+      + time_created       = (known after apply)
+      + time_last_modified = (known after apply)
+    }
+
+  # module.service_connector.oci_sch_service_connector.this will be created
+  + resource "oci_sch_service_connector" "this" {
+      + compartment_id    = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000"
+      + defined_tags      = (known after apply)
+      + description       = "Logging to Streaming connector"
+      + display_name      = "dry-run-service_connector_display_name"
+      + freeform_tags     = (known after apply)
+      + id                = (known after apply)
+      + lifecycle_details = (known after apply)
+      + lifecyle_details  = (known after apply)
+      + state             = (known after apply)
+      + system_tags       = (known after apply)
+      + time_created      = (known after apply)
+      + time_updated      = (known after apply)
+
+      + source {
+          + config_map                = (known after apply)
+          + kind                      = "logging"
+          + plugin_name               = (known after apply)
+          + private_endpoint_metadata = (known after apply)
+          + stream_id                 = (known after apply)
+
+          + log_sources {
+              + compartment_id = "ocid1.log_source_compartment.oc1..dryrun0000000000000000000000000000000000000000"
+              + log_group_id   = (known after apply)
+              + log_id         = (known after apply)
+            }
+        }
+
+      + target {
+          + batch_rollover_size_in_mbs = (known after apply)
+          + batch_rollover_time_in_ms  = (known after apply)
+          + batch_size_in_kbs          = (known after apply)
+          + batch_size_in_num          = (known after apply)
+          + batch_time_in_sec          = (known after apply)
+          + bucket                     = (known after apply)
+          + compartment_id             = (known after apply)
+          + enable_formatted_messaging = (known after apply)
+          + function_id                = (known after apply)
+          + kind                       = "streaming"
+          + log_group_id               = (known after apply)
+          + log_source_identifier      = (known after apply)
+          + metric                     = (known after apply)
+          + metric_namespace           = (known after apply)
+          + namespace                  = (known after apply)
+          + object_name_prefix         = (known after apply)
+          + private_endpoint_metadata  = (known after apply)
+          + stream_id                  = (known after apply)
+          + topic_id                   = (known after apply)
+        }
+    }
+
+  # module.streaming.oci_streaming_stream.this will be created
+  + resource "oci_streaming_stream" "this" {
+      + compartment_id          = (known after apply)
+      + defined_tags            = (known after apply)
+      + freeform_tags           = (known after apply)
+      + id                      = (known after apply)
+      + lifecycle_state_details = (known after apply)
+      + messages_endpoint       = (known after apply)
+      + name                    = "dry-run-stream_name"
+      + partitions              = 1
+      + retention_in_hours      = 24
+      + state                   = (known after apply)
+      + stream_pool_id          = (known after apply)
+      + time_created            = (known after apply)
+    }
+
+  # module.streaming.oci_streaming_stream_pool.this will be created
+  + resource "oci_streaming_stream_pool" "this" {
+      + compartment_id          = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000"
+      + defined_tags            = (known after apply)
+      + endpoint_fqdn           = (known after apply)
+      + freeform_tags           = (known after apply)
+      + id                      = (known after apply)
+      + is_private              = (known after apply)
+      + lifecycle_state_details = (known after apply)
+      + name                    = "dry-run-stream_pool_name"
+      + security_attributes     = (known after apply)
+      + state                   = (known after apply)
+      + time_created            = (known after apply)
+
+      + kafka_settings {
+          + auto_create_topics_enable = true
+          + bootstrap_servers         = (known after apply)
+          + log_retention_hours       = 24
+          + num_partitions            = 1
+        }
+    }
+
+Plan: 5 to add, 0 to change, 0 to destroy.
+
+Changes to Outputs:
+  + log_group_id         = (known after apply)
+  + log_id               = (known after apply)
+  + service_connector_id = (known after apply)
+  + stream_id            = (known after apply)
+  + stream_pool_id       = (known after apply)

--- a/logs-streaming-kafka-splunk/variables.tf
+++ b/logs-streaming-kafka-splunk/variables.tf
@@ -1,0 +1,133 @@
+variable "compartment_id" {
+  description = "OCID of the compartment where resources are created."
+  type        = string
+}
+
+variable "log_group_display_name" {
+  description = "Display name for the log group."
+  type        = string
+}
+
+variable "log_group_description" {
+  description = "Description for the log group."
+  type        = string
+  default     = "Log group for streaming log pipeline"
+}
+
+variable "log_display_name" {
+  description = "Display name for the log."
+  type        = string
+}
+
+variable "log_type" {
+  description = "Log type (SERVICE or CUSTOM)."
+  type        = string
+  default     = "SERVICE"
+}
+
+variable "log_is_enabled" {
+  description = "Whether the log is enabled."
+  type        = bool
+  default     = true
+}
+
+variable "log_retention_duration" {
+  description = "Retention duration for logs in days (30, 60, 90, 120, 150, 180)."
+  type        = number
+  default     = 30
+}
+
+variable "log_source_category" {
+  description = "Log source category for the logging service."
+  type        = string
+}
+
+variable "log_source_resource" {
+  description = "OCID of the resource emitting logs."
+  type        = string
+}
+
+variable "log_source_service" {
+  description = "Service generating logs (e.g., objectstorage)."
+  type        = string
+}
+
+variable "log_source_type" {
+  description = "Log source type (OCISERVICE)."
+  type        = string
+  default     = "OCISERVICE"
+}
+
+variable "log_source_parameters" {
+  description = "Optional log source parameters for OCI service logs."
+  type        = map(string)
+  default     = {}
+}
+
+variable "stream_pool_name" {
+  description = "Name for the streaming pool."
+  type        = string
+}
+
+variable "stream_name" {
+  description = "Name for the stream."
+  type        = string
+}
+
+variable "stream_partitions" {
+  description = "Number of partitions for the stream."
+  type        = number
+  default     = 1
+}
+
+variable "stream_retention_hours" {
+  description = "Retention period for the stream in hours."
+  type        = number
+  default     = 24
+}
+
+variable "kafka_auto_create_topics" {
+  description = "Enable auto topic creation for Kafka compatibility."
+  type        = bool
+  default     = true
+}
+
+variable "kafka_log_retention_hours" {
+  description = "Default Kafka log retention in hours."
+  type        = number
+  default     = 24
+}
+
+variable "kafka_default_partitions" {
+  description = "Default Kafka partitions for new topics."
+  type        = number
+  default     = 1
+}
+
+variable "service_connector_display_name" {
+  description = "Display name for the service connector."
+  type        = string
+}
+
+variable "service_connector_description" {
+  description = "Description for the service connector."
+  type        = string
+  default     = "Logging to Streaming connector"
+}
+
+variable "log_source_compartment_id" {
+  description = "Compartment OCID containing the log sources."
+  type        = string
+}
+
+variable "freeform_tags" {
+  description = "Freeform tags to apply to resources."
+  type        = map(string)
+  default     = {}
+}
+
+variable "defined_tags" {
+  description = "Defined tags to apply to resources."
+  type        = map(string)
+  default     = {}
+}

--- a/logs-streaming-kafka-splunk/versions.tf
+++ b/logs-streaming-kafka-splunk/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    oci = {
+      source  = "oracle/oci"
+      version = ">= 5.0.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds a new module-structured OCI Terraform template: `logs-streaming-kafka-splunk`.

## Module Structure
logs-streaming-kafka-splunk/.terraform.lock.hcl
logs-streaming-kafka-splunk/.terraform/modules/modules.json
logs-streaming-kafka-splunk/.terraform/providers/registry.terraform.io/oracle/oci/8.8.0/darwin_arm64/terraform-provider-oci_v8.8.0
logs-streaming-kafka-splunk/README.md
logs-streaming-kafka-splunk/main.tf
logs-streaming-kafka-splunk/modules/logging/main.tf
logs-streaming-kafka-splunk/modules/logging/outputs.tf
logs-streaming-kafka-splunk/modules/logging/variables.tf
logs-streaming-kafka-splunk/modules/logging/versions.tf
logs-streaming-kafka-splunk/modules/service-connector/main.tf
logs-streaming-kafka-splunk/modules/service-connector/outputs.tf
logs-streaming-kafka-splunk/modules/service-connector/variables.tf
logs-streaming-kafka-splunk/modules/service-connector/versions.tf
logs-streaming-kafka-splunk/modules/streaming/main.tf
logs-streaming-kafka-splunk/modules/streaming/outputs.tf
logs-streaming-kafka-splunk/modules/streaming/variables.tf
logs-streaming-kafka-splunk/modules/streaming/versions.tf
logs-streaming-kafka-splunk/outputs.tf
logs-streaming-kafka-splunk/plan.txt
logs-streaming-kafka-splunk/variables.tf
logs-streaming-kafka-splunk/versions.tf

## Terraform Plan
```

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  [32m+[0m create[0m

Terraform will perform the following actions:

[1m  # module.logging.oci_logging_log.this[0m will be created
[0m  [32m+[0m[0m resource "oci_logging_log" "this" {
      [32m+[0m[0m compartment_id     = (known after apply)
      [32m+[0m[0m defined_tags       = (known after apply)
      [32m+[0m[0m display_name       = "dry-run-log_display_name"
      [32m+[0m[0m freeform_tags      = (known after apply)
      [32m+[0m[0m id                 = (known after apply)
      [32m+[0m[0m is_enabled         = true
      [32m+[0m[0m log_group_id       = (known after apply)
      [32m+[0m[0m log_type           = "SERVICE"
      [32m+[0m[0m retention_duration = 30
      [32m+[0m[0m state              = (known after apply)
      [32m+[0m[0m tenancy_id         = (known after apply)
      [32m+[0m[0m time_created       = (known after apply)
      [32m+[0m[0m time_last_modified = (known after apply)

      [32m+[0m[0m configuration {
          [32m+[0m[0m compartment_id = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000"

          [32m+[0m[0m source {
              [32m+[0m[0m category    = "dummy-log_source_category"
              [32m+[0m[0m parameters  = (known after apply)
              [32m+[0m[0m resource    = "dummy-log_source_resource"
              [32m+[0m[0m service     = "dummy-log_source_service"
              [32m+[0m[0m source_type = "OCISERVICE"
            }
        }
    }

[1m  # module.logging.oci_logging_log_group.this[0m will be created
[0m  [32m+[0m[0m resource "oci_logging_log_group" "this" {
      [32m+[0m[0m compartment_id     = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000"
      [32m+[0m[0m defined_tags       = (known after apply)
      [32m+[0m[0m description        = "Log group for streaming log pipeline"
      [32m+[0m[0m display_name       = "dry-run-log_group_display_name"
      [32m+[0m[0m freeform_tags      = (known after apply)
      [32m+[0m[0m id                 = (known after apply)
      [32m+[0m[0m state              = (known after apply)
      [32m+[0m[0m time_created       = (known after apply)
      [32m+[0m[0m time_last_modified = (known after apply)
    }

[1m  # module.service_connector.oci_sch_service_connector.this[0m will be created
[0m  [32m+[0m[0m resource "oci_sch_service_connector" "this" {
      [32m+[0m[0m compartment_id    = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000"
      [32m+[0m[0m defined_tags      = (known after apply)
      [32m+[0m[0m description       = "Logging to Streaming connector"
      [32m+[0m[0m display_name      = "dry-run-service_connector_display_name"
      [32m+[0m[0m freeform_tags     = (known after apply)
      [32m+[0m[0m id                = (known after apply)
      [32m+[0m[0m lifecycle_details = (known after apply)
      [32m+[0m[0m lifecyle_details  = (known after apply)
      [32m+[0m[0m state             = (known after apply)
      [32m+[0m[0m system_tags       = (known after apply)
      [32m+[0m[0m time_created      = (known after apply)
      [32m+[0m[0m time_updated      = (known after apply)

      [32m+[0m[0m source {
          [32m+[0m[0m config_map                = (known after apply)
          [32m+[0m[0m kind                      = "logging"
          [32m+[0m[0m plugin_name               = (known after apply)
          [32m+[0m[0m private_endpoint_metadata = (known after apply)
          [32m+[0m[0m stream_id                 = (known after apply)

          [32m+[0m[0m log_sources {
              [32m+[0m[0m compartment_id = "ocid1.log_source_compartment.oc1..dryrun0000000000000000000000000000000000000000"
              [32m+[0m[0m log_group_id   = (known after apply)
              [32m+[0m[0m log_id         = (known after apply)
            }
        }

      [32m+[0m[0m target {
          [32m+[0m[0m batch_rollover_size_in_mbs = (known after apply)
          [32m+[0m[0m batch_rollover_time_in_ms  = (known after apply)
          [32m+[0m[0m batch_size_in_kbs          = (known after apply)
          [32m+[0m[0m batch_size_in_num          = (known after apply)
          [32m+[0m[0m batch_time_in_sec          = (known after apply)
          [32m+[0m[0m bucket                     = (known after apply)
          [32m+[0m[0m compartment_id             = (known after apply)
          [32m+[0m[0m enable_formatted_messaging = (known after apply)
          [32m+[0m[0m function_id                = (known after apply)
          [32m+[0m[0m kind                       = "streaming"
          [32m+[0m[0m log_group_id               = (known after apply)
          [32m+[0m[0m log_source_identifier      = (known after apply)
          [32m+[0m[0m metric                     = (known after apply)
          [32m+[0m[0m metric_namespace           = (known after apply)
          [32m+[0m[0m namespace                  = (known after apply)
          [32m+[0m[0m object_name_prefix         = (known after apply)
          [32m+[0m[0m private_endpoint_metadata  = (known after apply)
          [32m+[0m[0m stream_id                  = (known after apply)
          [32m+[0m[0m topic_id                   = (known after apply)
        }
    }

[1m  # module.streaming.oci_streaming_stream.this[0m will be created
[0m  [32m+[0m[0m resource "oci_streaming_stream" "this" {
      [32m+[0m[0m compartment_id          = (known after apply)
      [32m+[0m[0m defined_tags            = (known after apply)
      [32m+[0m[0m freeform_tags           = (known after apply)
      [32m+[0m[0m id                      = (known after apply)
      [32m+[0m[0m lifecycle_state_details = (known after apply)
      [32m+[0m[0m messages_endpoint       = (known after apply)
      [32m+[0m[0m name                    = "dry-run-stream_name"
      [32m+[0m[0m partitions              = 1
      [32m+[0m[0m retention_in_hours      = 24
      [32m+[0m[0m state                   = (known after apply)
      [32m+[0m[0m stream_pool_id          = (known after apply)
      [32m+[0m[0m time_created            = (known after apply)
    }

[1m  # module.streaming.oci_streaming_stream_pool.this[0m will be created
[0m  [32m+[0m[0m resource "oci_streaming_stream_pool" "this" {
      [32m+[0m[0m compartment_id          = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000"
      [32m+[0m[0m defined_tags            = (known after apply)
      [32m+[0m[0m endpoint_fqdn           = (known after apply)
      [32m+[0m[0m freeform_tags           = (known after apply)
      [32m+[0m[0m id                      = (known after apply)
      [32m+[0m[0m is_private              = (known after apply)
      [32m+[0m[0m lifecycle_state_details = (known after apply)
      [32m+[0m[0m name                    = "dry-run-stream_pool_name"
      [32m+[0m[0m security_attributes     = (known after apply)
      [32m+[0m[0m state                   = (known after apply)
      [32m+[0m[0m time_created            = (known after apply)

      [32m+[0m[0m kafka_settings {
          [32m+[0m[0m auto_create_topics_enable = true
          [32m+[0m[0m bootstrap_servers         = (known after apply)
          [32m+[0m[0m log_retention_hours       = 24
          [32m+[0m[0m num_partitions            = 1
        }
    }

[1mPlan:[0m 5 to add, 0 to change, 0 to destroy.
[0m
Changes to Outputs:
  [32m+[0m[0m log_group_id         = (known after apply)
  [32m+[0m[0m log_id               = (known after apply)
  [32m+[0m[0m service_connector_id = (known after apply)
  [32m+[0m[0m stream_id            = (known after apply)
  [32m+[0m[0m stream_pool_id       = (known after apply)
[90m
─────────────────────────────────────────────────────────────────────────────[0m

Saved the plan to: plan.out

To perform exactly these actions, run the following command to apply:
    terraform apply "plan.out"

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.logging.oci_logging_log.this will be created
  + resource "oci_logging_log" "this" {
      + compartment_id     = (known after apply)
      + defined_tags       = (known after apply)
      + display_name       = "dry-run-log_display_name"
      + freeform_tags      = (known after apply)
      + id                 = (known after apply)
      + is_enabled         = true
      + log_group_id       = (known after apply)
      + log_type           = "SERVICE"
      + retention_duration = 30
      + state              = (known after apply)
      + tenancy_id         = (known after apply)
      + time_created       = (known after apply)
      + time_last_modified = (known after apply)

      + configuration {
          + compartment_id = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000"

          + source {
              + category    = "dummy-log_source_category"
              + parameters  = (known after apply)
              + resource    = "dummy-log_source_resource"
              + service     = "dummy-log_source_service"
              + source_type = "OCISERVICE"
            }
        }
    }

  # module.logging.oci_logging_log_group.this will be created
  + resource "oci_logging_log_group" "this" {
      + compartment_id     = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000"
      + defined_tags       = (known after apply)
      + description        = "Log group for streaming log pipeline"
      + display_name       = "dry-run-log_group_display_name"
      + freeform_tags      = (known after apply)
      + id                 = (known after apply)
      + state              = (known after apply)
      + time_created       = (known after apply)
      + time_last_modified = (known after apply)
    }

  # module.service_connector.oci_sch_service_connector.this will be created
  + resource "oci_sch_service_connector" "this" {
      + compartment_id    = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000"
      + defined_tags      = (known after apply)
      + description       = "Logging to Streaming connector"
      + display_name      = "dry-run-service_connector_display_name"
      + freeform_tags     = (known after apply)
      + id                = (known after apply)
      + lifecycle_details = (known after apply)
      + lifecyle_details  = (known after apply)
      + state             = (known after apply)
      + system_tags       = (known after apply)
      + time_created      = (known after apply)
      + time_updated      = (known after apply)

      + source {
          + config_map                = (known after apply)
          + kind                      = "logging"
          + plugin_name               = (known after apply)
          + private_endpoint_metadata = (known after apply)
          + stream_id                 = (known after apply)

          + log_sources {
              + compartment_id = "ocid1.log_source_compartment.oc1..dryrun0000000000000000000000000000000000000000"
              + log_group_id   = (known after apply)
              + log_id         = (known after apply)
            }
        }

      + target {
          + batch_rollover_size_in_mbs = (known after apply)
          + batch_rollover_time_in_ms  = (known after apply)
          + batch_size_in_kbs          = (known after apply)
          + batch_size_in_num          = (known after apply)
          + batch_time_in_sec          = (known after apply)
          + bucket                     = (known after apply)
          + compartment_id             = (known after apply)
          + enable_formatted_messaging = (known after apply)
          + function_id                = (known after apply)
          + kind                       = "streaming"
          + log_group_id               = (known after apply)
          + log_source_identifier      = (known after apply)
          + metric                     = (known after apply)
          + metric_namespace           = (known after apply)
          + namespace                  = (known after apply)
          + object_name_prefix         = (known after apply)
          + private_endpoint_metadata  = (known after apply)
          + stream_id                  = (known after apply)
          + topic_id                   = (known after apply)
        }
    }

  # module.streaming.oci_streaming_stream.this will be created
  + resource "oci_streaming_stream" "this" {
      + compartment_id          = (known after apply)
      + defined_tags            = (known after apply)
      + freeform_tags           = (known after apply)
      + id                      = (known after apply)
      + lifecycle_state_details = (known after apply)
      + messages_endpoint       = (known after apply)
      + name                    = "dry-run-stream_name"
      + partitions              = 1
      + retention_in_hours      = 24
      + state                   = (known after apply)
      + stream_pool_id          = (known after apply)
      + time_created            = (known after apply)
    }

  # module.streaming.oci_streaming_stream_pool.this will be created
  + resource "oci_streaming_stream_pool" "this" {
      + compartment_id          = "ocid1.compartment.oc1..dryrun0000000000000000000000000000000000000000"
      + defined_tags            = (known after apply)
      + endpoint_fqdn           = (known after apply)
      + freeform_tags           = (known after apply)
      + id                      = (known after apply)
      + is_private              = (known after apply)
      + lifecycle_state_details = (known after apply)
      + name                    = "dry-run-stream_pool_name"
      + security_attributes     = (known after apply)
      + state                   = (known after apply)
      + time_created            = (known after apply)

      + kafka_settings {
          + auto_create_topics_enable = true
          + bootstrap_servers         = (known after apply)
          + log_retention_hours       = 24
          + num_partitions            = 1
        }
    }

Plan: 5 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + log_group_id         = (known after apply)
  + log_id               = (known after apply)
  + service_connector_id = (known after apply)
  + stream_id            = (known after apply)
  + stream_pool_id       = (known after apply)
```